### PR TITLE
Update setup.cfg, exclude 'tests'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,6 @@ install_requires =
     Authlib
     httpx
     pytz
+    
+[options.packages.find]
+exclude = tests


### PR DESCRIPTION
otherwise it tries to install a package called 'tests' at top level:

```
>>> Emerging (1 of 1) dev-python/pylitterbot-2021.3.1::HomeAssistantRepository
>>> Failed to emerge dev-python/pylitterbot-2021.3.1, Log file:
>>>  '/var/tmp/portage/dev-python/pylitterbot-2021.3.1/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.65, 0.52, 0.42
 * Package:    dev-python/pylitterbot-2021.3.1
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   natekspencer@gmail.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_8 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking pylitterbot-2021.3.1.tar.gz to /var/tmp/portage/dev-python/pylitterbot-2021.3.1/work
>>> Source unpacked in /var/tmp/portage/dev-python/pylitterbot-2021.3.1/work
>>> Preparing source in /var/tmp/portage/dev-python/pylitterbot-2021.3.1/work/pylitterbot-2021.3.1 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/pylitterbot-2021.3.1/work/pylitterbot-2021.3.1 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/pylitterbot-2021.3.1/work/pylitterbot-2021.3.1 ...
 * python3_8: running distutils-r1_run_phase distutils-r1_python_compile
python3.8 setup.py build -j 10
running build
running build_py
running install_egg_info
running egg_info
writing pylitterbot.egg-info/PKG-INFO
writing dependency_links to pylitterbot.egg-info/dependency_links.txt
writing requirements to pylitterbot.egg-info/requires.txt
writing top-level names to pylitterbot.egg-info/top_level.txt
reading manifest file 'pylitterbot.egg-info/SOURCES.txt'
writing manifest file 'pylitterbot.egg-info/SOURCES.txt'
Copying pylitterbot.egg-info to /var/tmp/portage/dev-python/pylitterbot-2021.3.1/image/_python3.8/usr/lib/python3.8/site-packages/pylitterbot-2021.3.1-py3.8.egg-info
running install_scripts
 * ERROR: dev-python/pylitterbot-2021.3.1::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
```