### PR TITLE
Add py.typed file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,9 @@ install_requires =
 [options.packages.find]
 exclude = tests
 
+[options.package_data]
+* = py.typed
+
 [options.extras_require]
 test =
     pytest


### PR DESCRIPTION
The `py.typed` file is necessary for mypy to know that the library includes types.
This will help remove some of the `type: ignores` from https://github.com/home-assistant/core/pull/75540.

Although preferred, it's not strictly necessary for a library to be fully typed in order to add `py.typed`. As long as the existing types are good enough and don't cause any issue, it's fine to add. The types can still be refined later.

https://peps.python.org/pep-0561/