### PR TITLE
Adjust Activity and Insight classes and implement  get_activity_history on Litter-Robot 4

### DIFF
--- a/pylitterbot/activity.py
+++ b/pylitterbot/activity.py
@@ -13,12 +13,11 @@ class Activity:
     """Represents a historical activity for a Litter-Robot."""
 
     timestamp: datetime | date
-    unit_status: LitterBoxStatus = LitterBoxStatus.UNKNOWN
-    count: int = 1
+    action: str | LitterBoxStatus
 
     def __str__(self) -> str:
         """Return self(str)."""
-        return f"{self.timestamp.isoformat()}: {self.unit_status.text} - {pluralize('cycle', self.count)}"
+        return f"{self.timestamp.isoformat()}: {self.action.text if isinstance(self.action, LitterBoxStatus) else self.action}"
 
 
 @dataclass
@@ -27,7 +26,7 @@ class Insight:
 
     total_cycles: int
     average_cycles: float
-    cycle_history: list[Activity]
+    cycle_history: list[tuple[date, int]]
 
     @property
     def total_days(self) -> int:

--- a/pylitterbot/robot/__init__.py
+++ b/pylitterbot/robot/__init__.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from deepdiff import DeepDiff
 
-from ..utils import from_litter_robot_timestamp, urljoin
+from ..utils import to_timestamp, urljoin
 
 if TYPE_CHECKING:
     from ..account import Account
@@ -92,7 +92,7 @@ class Robot:
     @property
     def setup_date(self) -> datetime | None:
         """Return the datetime the robot was onboarded, if any."""
-        return from_litter_robot_timestamp(self._data.get(self._data_setup_date))
+        return to_timestamp(self._data.get(self._data_setup_date))
 
     def emit(self, event_name: str, *args: Any, **kwargs: Any) -> None:
         """Run all callbacks for an event."""
@@ -143,18 +143,14 @@ class Robot:
     def _update_data(self, data: dict, partial: bool = False) -> None:
         """Save the robot info from a data dictionary."""
         if self._is_loaded:
-            _LOGGER.debug(
-                "%s updated: %s",
-                self.name,
-                DeepDiff(
-                    self._data,
-                    {**self._data, **data} if partial else data,
-                    ignore_order=True,
-                    report_repetition=True,
-                    verbose_level=2,
-                )
-                or "no changes detected",
-            )
+            if diff := DeepDiff(
+                self._data,
+                {**self._data, **data} if partial else data,
+                ignore_order=True,
+                report_repetition=True,
+                verbose_level=2,
+            ):
+                _LOGGER.debug("%s updated: %s", self.name, diff)
 
         self._data.update(data)
         self._is_loaded = True

--- a/pylitterbot/robot/litterrobot.py
+++ b/pylitterbot/robot/litterrobot.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from ..activity import Activity, Insight
 from ..enums import LitterBoxCommand, LitterBoxStatus
-from ..utils import from_litter_robot_timestamp, send_deprecation_warning
+from ..utils import send_deprecation_warning, to_timestamp
 from . import Robot
 
 _LOGGER = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ class LitterRobot(Robot):
     @property
     def last_seen(self) -> datetime | None:
         """Return the datetime the Litter-Robot last reported, if any."""
-        return from_litter_robot_timestamp(self._data.get("lastSeen"))
+        return to_timestamp(self._data.get("lastSeen"))
 
     @property
     def power_status(self) -> str:

--- a/pylitterbot/utils.py
+++ b/pylitterbot/utils.py
@@ -28,7 +28,13 @@ def encode(value: str | dict) -> str:
 
 def from_litter_robot_timestamp(
     timestamp: str | None,
-) -> datetime | None:
+) -> datetime | None:  # pragma: no cover
+    """Use `to_timestamp` instead."""
+    send_deprecation_warning("from_litter_robot_timestamp", "to_timestamp")
+    return to_timestamp(timestamp)
+
+
+def to_timestamp(timestamp: str | None) -> datetime | None:
     """Construct a UTC offset-aware datetime from a Litter-Robot API timestamp."""
     if not timestamp:
         return None
@@ -36,7 +42,7 @@ def from_litter_robot_timestamp(
         timestamp = timestamp.replace("Z", "")
     if (utc_offset := "+00:00") not in timestamp:
         timestamp += utc_offset
-    timestamp = re.sub(r"(\.\d+)", lambda m: m.group().ljust(7, "0"), timestamp)
+    timestamp = re.sub(r"(\.\d+)", lambda m: m.group().ljust(7, "0")[:7], timestamp)
     return datetime.fromisoformat(timestamp)
 
 

--- a/tests/test_feederrobot.py
+++ b/tests/test_feederrobot.py
@@ -120,7 +120,4 @@ async def test_feeder_robot(
     assert await robot.set_name(new_name)
     assert robot.name == new_name
 
-    assert not await robot.get_activity_history()
-    assert (await robot.get_insight()).total_cycles == 0
-
     await robot._account.disconnect()

--- a/tests/test_litterrobot4.py
+++ b/tests/test_litterrobot4.py
@@ -75,9 +75,38 @@ async def test_litter_robot_4(
 
     assert await robot.start_cleaning()
 
-    assert await robot.get_activity_history() == []
-
     mock_aioresponse.clear()
+    mock_aioresponse.post(
+        LR4_ENDPOINT,
+        payload={
+            "data": {
+                "getLitterRobot4Activity": [
+                    {
+                        "timestamp": "2022-09-17 20:53:32.000000000",
+                        "value": "robotCycleStatusIdle",
+                        "actionValue": "",
+                    },
+                    {
+                        "timestamp": "2022-09-17 20:51:18.000000000",
+                        "value": "robotCycleStatusDump",
+                        "actionValue": "",
+                    },
+                    {
+                        "timestamp": "2022-09-17 20:44:18.000000000",
+                        "value": "catWeight",
+                        "actionValue": "6.35",
+                    },
+                ]
+            }
+        },
+    )
+    activities = await robot.get_activity_history(3)
+    assert len(activities) == 3
+    assert activities[0].action == LitterBoxStatus.CLEAN_CYCLE_COMPLETE
+    assert activities[2].action == "Pet Weight Recorded: 6.35 lbs"
+    with pytest.raises(InvalidCommandException):
+        await robot.get_activity_history(0)
+
     mock_aioresponse.post(
         LR4_ENDPOINT,
         payload={

--- a/tests/test_robot.py
+++ b/tests/test_robot.py
@@ -260,7 +260,7 @@ async def test_other_commands(mock_aioresponse: aioresponses) -> None:
     history = await robot.get_activity_history(2)
     assert history
     assert len(history) == 2
-    assert str(history[0]) == "2021-03-01T00:01:00+00:00: Ready - 1 cycle"
+    assert str(history[0]) == "2021-03-01T00:01:00+00:00: Ready"
 
     insight = await robot.get_insight(2)
     assert insight

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 """Test utils module."""
-from pylitterbot.utils import decode, encode, from_litter_robot_timestamp, round_time
+from pylitterbot.utils import decode, encode, round_time, to_timestamp
 
 
 def test_round_time_default() -> None:
@@ -8,9 +8,10 @@ def test_round_time_default() -> None:
     assert timestamp
 
 
-def test_from_litter_robot_timestamp() -> None:
+def test_to_timestamp() -> None:
     """Tests parsing a Litter-Robot timestamp."""
-    assert from_litter_robot_timestamp(None) is None
+    assert to_timestamp(None) is None
+    assert to_timestamp("2022-09-14") is not None
 
 
 def test_encode_decode() -> None:


### PR DESCRIPTION
## Breaking Changes
* `Activity` class (`get_activity_history` method of `LitterRobot`)
  * Removed `unit_status` and `count`
  * Added `action` which can be a `LitterBoxStatus` or `str`
* `Insight` class (`get_insight` method of `LitterRobot`)
  * `cycle_history` type is now `list[tuple[date, int]]` rather than `list[Activity]`
* Removed `get_activity_history` and `get_insight` from `FeederRobot`
* `from_litter_robot_timestamp` has been renamed to `to_timestamp`