### PR TITLE
Use a single web socket monitor per robot class/endpoint

### DIFF
--- a/pylitterbot/robot/__init__.py
+++ b/pylitterbot/robot/__init__.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from aiohttp import ClientWebSocketResponse
 from deepdiff import DeepDiff
 
 from ..utils import to_timestamp, urljoin
@@ -38,6 +39,8 @@ class Robot:
 
         self._is_loaded = False
         self._listeners: dict[str, list[Callable]] = {}
+
+        self._ws: ClientWebSocketResponse | None = None
 
         if data:
             self._update_data(data)
@@ -186,3 +189,13 @@ class Robot:
         return await self._account.session.post(
             urljoin(self._path, subpath), json=json, **kwargs
         )
+
+    @staticmethod
+    async def get_websocket_config(account: Account) -> dict[str, Any]:
+        """Get wesocket config."""
+        raise NotImplementedError()
+
+    @staticmethod
+    def parse_websocket_message(data: dict) -> dict | None:
+        """Parse a wesocket message."""
+        raise NotImplementedError()

--- a/pylitterbot/robot/__init__.py
+++ b/pylitterbot/robot/__init__.py
@@ -147,6 +147,7 @@ class Robot:
         try:
             self._ws = await self._account.ws_connect(self)
             await self.send_subscribe_request()
+            _LOGGER.debug("%s subscribed to updates", self.name)
         except Exception as ex:  # pylint: disable=broad-except
             _LOGGER.error(ex)
 

--- a/pylitterbot/robot/feederrobot.py
+++ b/pylitterbot/robot/feederrobot.py
@@ -48,7 +48,6 @@ class FeederRobot(Robot):  # pylint: disable=abstract-method
         """Initialize a Feeder-Robot."""
         super().__init__(data, account)
         self._path = FEEDER_ENDPOINT
-        self._ws_subscription_id: str | None = None
 
     def _state_info(self, key: str, default: _T | None = None) -> _T | Any:
         """Get an attribute from the data.state.info section."""
@@ -245,54 +244,38 @@ class FeederRobot(Robot):  # pylint: disable=abstract-method
             self._update_data(data)
         return self.panel_lock_enabled == value
 
-    async def subscribe_for_updates(self) -> None:
-        """Open a web socket connection to receive updates."""
+    async def send_subscribe_request(self, send_stop: bool = False) -> None:
+        """Send a subscribe request and, optionally, unsubscribe from a previous subscription."""
+        if not self._ws:
+            return
+        if send_stop:
+            await self.send_unsubscribe_request()
+        self._ws_subscription_id = str(uuid4())
 
-        async def _subscribe(send_stop: bool = False) -> None:
-            if not self._ws:
-                return
-            if send_stop:
-                await self._ws.send_json(
-                    {"id": self._ws_subscription_id, "type": "stop"}
-                )
-            self._ws_subscription_id = str(uuid4())
-            await self._ws.send_json(
-                {
-                    "type": "connection_init",
-                    "payload": {
-                        "headers": {
-                            "Authorization": await self._account.get_bearer_authorization()
-                        }
-                    },
-                }
-            )
-            await self._ws.send_json(
-                {
-                    "type": "start",
-                    "id": self._ws_subscription_id,
-                    "payload": {
-                        "query": f"""
+        await self._ws.send_json(
+            {
+                "type": "connection_init",
+                "payload": {
+                    "headers": {
+                        "Authorization": await self._account.get_bearer_authorization()
+                    }
+                },
+            }
+        )
+        await self._ws.send_json(
+            {
+                "type": "start",
+                "id": self._ws_subscription_id,
+                "payload": {
+                    "query": f"""
                             subscription GetFeeder($id: Int!) {{
                                 feeder_unit_by_pk(id: $id) {FEEDER_ROBOT_MODEL}
                             }}
                         """,
-                        "variables": {"id": self.id},
-                    },
-                }
-            )
-
-        try:
-            self._ws = await self._account.ws_connect(self)
-            await _subscribe()
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.error(ex)
-
-    async def unsubscribe_from_updates(self) -> None:
-        """Stop the web socket."""
-        if (websocket := self._ws) is not None and not websocket.closed:
-            self._ws = None
-            await websocket.send_json({"id": self._ws_subscription_id, "type": "stop"})
-            _LOGGER.debug("Unsubscribed from updates")
+                    "variables": {"id": self.id},
+                },
+            }
+        )
 
     @staticmethod
     async def get_websocket_config(account: Account) -> dict[str, Any]:

--- a/pylitterbot/robot/litterrobot3.py
+++ b/pylitterbot/robot/litterrobot3.py
@@ -278,25 +278,15 @@ class LitterRobot3(LitterRobot):
             ],
         )
 
-    async def subscribe_for_updates(self) -> None:
-        """Open a web socket connection to receive updates."""
+    async def send_subscribe_request(self, send_stop: bool = False) -> None:
+        """Send a subscribe request and, optionally, unsubscribe from a previous subscription."""
+        if not self._ws:
+            return
+        await self._ws.send_json({"action": "ping"})
 
-        async def _subscribe() -> None:
-            if not self._ws:
-                return
-            await self._ws.send_json({"action": "ping"})
-
-        try:
-            self._ws = await self._account.ws_connect(self)
-            await _subscribe()
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.error(ex)
-
-    async def unsubscribe_from_updates(self) -> None:
-        """Stop the web socket."""
-        if (websocket := self._ws) is not None and not websocket.closed:
-            self._ws = None
-            _LOGGER.debug("Unsubscribed from updates")
+    async def send_unsubscribe_request(self) -> None:
+        """Send an unsubscribe request."""
+        # Litter-Robot 3 does not have a subscription id, so this just does nothing
 
     @staticmethod
     async def get_websocket_config(account: Account) -> dict[str, Any]:

--- a/pylitterbot/ws_monitor.py
+++ b/pylitterbot/ws_monitor.py
@@ -1,0 +1,99 @@
+"""Websocket monitor."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from json import loads
+from typing import TYPE_CHECKING
+
+from aiohttp import ClientWebSocketResponse, WSMsgType
+
+from .robot import Robot
+from .utils import utcnow
+
+if TYPE_CHECKING:
+    from .account import Account
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WebSocketMonitor:
+    """Web socket monitor for a robot."""
+
+    def __init__(self, account: Account, robot_class: type[Robot]) -> None:
+        """Initialize a web socket monitor."""
+        self._account = account
+        self._robot_class = robot_class
+        self._ws: ClientWebSocketResponse | None = None
+        self._monitor_task: asyncio.Task | None = None
+        self._last_received: datetime | None = None
+
+    @property
+    def websocket(self) -> ClientWebSocketResponse | None:
+        """Return the web socket."""
+        return self._ws
+
+    @property
+    def monitor(self) -> asyncio.Task | None:
+        """Return the monitor task."""
+        return self._monitor_task
+
+    async def new_connection(self) -> None:
+        """Create a new connection."""
+        self._ws = await self._account.session.websession.ws_connect(
+            **await self._robot_class.get_websocket_config(self._account)
+        )
+
+    async def _monitor(self) -> None:
+        """Monitor a web socket."""
+        if not self._ws:
+            return
+        while True:
+            try:
+                msg = await self._ws.receive(timeout=80)
+                if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED):
+                    break
+                self._last_received = utcnow()
+                if msg.type == WSMsgType.TEXT:
+                    data = loads(msg.data)
+                    # pylint: disable=protected-access
+                    if (data := self._robot_class.parse_websocket_message(data)) and (
+                        robot := self._account.get_robot(
+                            data.get(self._robot_class._data_id)
+                        )
+                    ):
+                        robot._update_data(data)
+                elif msg.type == WSMsgType.ERROR:
+                    _LOGGER.error(msg)
+                    break
+            except asyncio.TimeoutError:
+                _LOGGER.debug("Web socket monitor did not receive a message in time")
+                # should we resubscribe?
+                # await _subscribe(send_stop=True)
+        _LOGGER.debug("Web socket monitor stopped")
+        if self._ws is not None:
+            if self._ws.closed:
+                pass  # restart?
+                # await self.subscribe_for_updates()
+                # _LOGGER.debug("restarted connection")
+            else:
+                pass  # resubscribe?
+                # await self._start_ws_monitor(ws_monitor)
+                # await _subscribe()
+                # _LOGGER.debug("resubscribed")
+
+    async def start_monitor(self) -> None:
+        """Start or restart the monitor task."""
+        if (task := self._monitor_task) is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._monitor_task = asyncio.ensure_future(self._monitor())
+
+    async def close(self) -> None:
+        """Close the web socket."""
+        if self._ws:
+            await self._ws.close()

--- a/tests/test_feederrobot.py
+++ b/tests/test_feederrobot.py
@@ -19,8 +19,8 @@ async def test_feeder_robot(
 ) -> None:
     """Tests that a Feeder-Robot setup is successful and parses as expected."""
     robot = FeederRobot(data=FEEDER_ROBOT_DATA, account=mock_account)
-    await robot.subscribe_for_updates()
-    await robot.unsubscribe_from_updates()
+    await robot.subscribe()
+    await robot.unsubscribe()
     assert (
         str(robot)
         == "Name: Feeder-Robot, Model: Feeder-Robot, Serial: RF1C000001, id: 1"

--- a/tests/test_litterrobot4.py
+++ b/tests/test_litterrobot4.py
@@ -28,8 +28,8 @@ async def test_litter_robot_4(
 ) -> None:
     """Tests that a Litter-Robot 4 setup is successful and parses as expected."""
     robot = LitterRobot4(data=LITTER_ROBOT_4_DATA, account=mock_account)
-    await robot.subscribe_for_updates()
-    await robot.unsubscribe_from_updates()
+    await robot.subscribe()
+    await robot.unsubscribe()
     assert (
         str(robot)
         == "Name: Litter-Robot 4, Model: Litter-Robot 4, Serial: LR4C000001, id: LR4ID"


### PR DESCRIPTION
Fixes an issue where multiple robots of the same type throws an error on concurrent web socket receive calls