### PR TITLE
Use asyncio.Lock instead of threading.Lock

### DIFF
--- a/pylitterbot/session.py
+++ b/pylitterbot/session.py
@@ -79,7 +79,7 @@ class Session(Event, ABC):
         """Refresh the access token."""
         if self._token is None:
             return None
-        with self._lock:
+        async with self._lock:
             if not ignore_unexpired and self.is_token_valid():
                 return
             self._token = await self._refresh_token()

--- a/pylitterbot/session.py
+++ b/pylitterbot/session.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from threading import Lock
+from asyncio import Lock
 from types import TracebackType
 from typing import Any, TypeVar, cast
 
@@ -83,7 +83,7 @@ class Session(Event, ABC):
             if not ignore_unexpired and self.is_token_valid():
                 return
             self._token = await self._refresh_token()
-            self.emit(EVENT_UPDATE)
+        self.emit(EVENT_UPDATE)
 
     @abstractmethod
     async def _refresh_token(self) -> dict:
@@ -167,7 +167,6 @@ class LitterRobotSession(Session):
 
         self._token = token
         self._custom_args: dict = {}
-        self._lock = Lock()
 
     def generate_args(self, url: str, **kwargs: Any) -> dict[str, Any]:
         """Generate args."""


### PR DESCRIPTION
Apparently using threading.Lock locks up the whole thread. In Home Assistant this caused the whole HTTP thread to clog up and make HA break (https://github.com/home-assistant/core/issues/101209).

Had a small talk with Frenck, and this change might fix it, but I am not 100% sure, so if you could give it a test run on your HA dev environment, that would be awesome!