### PR TITLE
Parse `odometerCleanCycles` and `litterHopperDispensed` activities

### DIFF
--- a/pylitterbot/robot/litterrobot4.py
+++ b/pylitterbot/robot/litterrobot4.py
@@ -44,6 +44,8 @@ ACTIVITY_STATUS_MAP: dict[str, LitterBoxStatus | str] = {
     "catDetectStuckLaser": LitterBoxStatus.CAT_SENSOR_FAULT,
     "catWeight": "Pet Weight Recorded",
     "DFIFullFlagOn": LitterBoxStatus.DRAWER_FULL,
+    "litterHopperDispensed": "Litter Dispensed",
+    "odometerCleanCycles": "Clean Cycles",
     "powerTypeDC": "Battery Backup",
     "robotCycleStateCatDetect": LitterBoxStatus.CAT_SENSOR_INTERRUPTED,
     "robotCycleStatusDump": LitterBoxStatus.CLEAN_CYCLE,
@@ -413,6 +415,11 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
         action = ACTIVITY_STATUS_MAP.get(value, value)
         if value == "catWeight":
             action = f"{action}: {activity['actionValue']} lbs"
+        if value == self._data_cycle_count:
+            action = f"{action}: {activity['actionValue']}"
+        if value == "litterHopperDispensed":
+            # TODO: figure out what this value refers to. Could it be a fraction of lbs? Number of motor revolutions?
+            action = f"{action}: {activity['actionValue']}"
         return action
 
     def _parse_sleep_info(self) -> None:

--- a/tests/test_litterrobot4.py
+++ b/tests/test_litterrobot4.py
@@ -97,14 +97,26 @@ async def test_litter_robot_4(
                         "value": "catWeight",
                         "actionValue": "6.35",
                     },
+                    {
+                        "timestamp": "2022-09-17 20:40:07.000000000",
+                        "value": "odometerCleanCycles",
+                        "actionValue": "42",
+                    },
+                    {
+                        "timestamp": "2022-09-17 20:39:56.000000000",
+                        "value": "litterHopperDispensed",
+                        "actionValue": "84",
+                    },
                 ]
             }
         },
     )
-    activities = await robot.get_activity_history(3)
-    assert len(activities) == 3
+    activities = await robot.get_activity_history(5)
+    assert len(activities) == 5
     assert activities[0].action == LitterBoxStatus.CLEAN_CYCLE_COMPLETE
     assert activities[2].action == "Pet Weight Recorded: 6.35 lbs"
+    assert activities[3].action == "Clean Cycles: 42"
+    assert activities[4].action == "Litter Dispensed: 84"
     with pytest.raises(InvalidCommandException):
         await robot.get_activity_history(0)
 


### PR DESCRIPTION
Incremental improvement to #247. Also parses clean cycle count nicely. Open to any string format structure.

I noticed that my `litterHopperDispensed` activities do expose an action value. What it actually means is still unknown to me. It could be hundredths of a pound or perhaps number of motor servo revolutions?

Here are some real world values from my hopper:

```
2025-05-09T12:55:04+00:00: Litter Dispensed: 85
2025-05-08T16:36:40+00:00: Litter Dispensed: 84
2025-05-07T05:57:47+00:00: Litter Dispensed: 81
2025-05-06T16:26:49+00:00: Litter Dispensed: 83
2025-05-05T21:28:48+00:00: Litter Dispensed: 83
2025-05-05T03:15:03+00:00: Litter Dispensed: 84
2025-05-03T21:39:12+00:00: Litter Dispensed: 83
```