### PR TITLE
Revert "Add missing 8 minute cycle delay to LR4"

### DIFF
--- a/pylitterbot/robot/litterrobot4.py
+++ b/pylitterbot/robot/litterrobot4.py
@@ -169,7 +169,7 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
 
     _attr_model = "Litter-Robot 4"
 
-    VALID_WAIT_TIMES = [3, 7, 8, 15, 25, 30]
+    VALID_WAIT_TIMES = [3, 7, 15, 25, 30]
 
     _data_cycle_capacity = "DFINumberOfCycles"
     _data_cycle_count = "odometerCleanCycles"


### PR DESCRIPTION
The 8 minute option only seems to appear after a firmware update but is otherwise not an option within the whisker app
Reverts natekspencer/pylitterbot#306