### PR TITLE
Add LR5 Pro camera support: REST API and WebRTC streaming

### DIFF
--- a/pylitterbot/account.py
+++ b/pylitterbot/account.py
@@ -15,12 +15,13 @@ from aiohttp import (
 )
 from botocore.exceptions import ClientError
 
+from .const import API_V2_ENDPOINT, API_V2_ENDPOINT_KEY
 from .event import EVENT_UPDATE
 from .exceptions import LitterRobotException, LitterRobotLoginException
 from .pet import Pet
 from .robot import Robot
 from .robot.feederrobot import FeederRobot
-from .robot.litterrobot3 import DEFAULT_ENDPOINT, DEFAULT_ENDPOINT_KEY, LitterRobot3
+from .robot.litterrobot3 import LitterRobot3
 from .robot.litterrobot4 import LitterRobot4
 from .robot.litterrobot5 import LitterRobot5
 from .session import LitterRobotSession
@@ -49,8 +50,8 @@ class Account:
     ) -> None:
         """Initialize the account data."""
         self._session = LitterRobotSession(token=token, websession=websession)
-        self._session._custom_args[DEFAULT_ENDPOINT] = {
-            "headers": {"x-api-key": decode(DEFAULT_ENDPOINT_KEY)}
+        self._session._custom_args[API_V2_ENDPOINT] = {
+            "headers": {"x-api-key": decode(API_V2_ENDPOINT_KEY)}
         }
         self._user_id = self._session.get_user_id() if token else None
         self._user: dict = {}
@@ -174,7 +175,7 @@ class Account:
         """Refresh the logged in user's info."""
         data = cast(
             dict,
-            await self.session.get(urljoin(DEFAULT_ENDPOINT, f"users/{self.user_id}")),
+            await self.session.get(urljoin(API_V2_ENDPOINT, f"users/{self.user_id}")),
         )
         self._user.update(data.get("user", {}))
 

--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -264,9 +264,10 @@ class CameraClient:
             return []
         if not isinstance(data, list):
             return []
-        return [
+        clips = [
             VideoClip.from_response(item) for item in data if isinstance(item, dict)
         ]
+        return clips[:limit] if limit is not None else clips
 
     async def get_events(self, *, limit: int | None = None) -> list[dict[str, Any]]:
         """Fetch camera events (AI detections, etc.).
@@ -488,41 +489,44 @@ class CameraSignalingRelay:
         closes the WebSocket.  Browser ICE candidates that arrive after closure are
         buffered here and delivered via a fresh connection to the same session URL,
         allowing the camera to complete ICE negotiation.
+
+        Loops until the pending queue is empty, so candidates arriving during an
+        in-flight flush are not stranded.
         """
-        if not self._session or not self._pending_candidates:
-            return
-        _LOGGER.debug(
-            "Signaling relay: reconnecting to forward %d late ICE candidate(s)",
-            len(self._pending_candidates),
-        )
-        try:
-            websession = self._client.websession
-            ws_url = (
-                f"{self._session.signaling_url}"
-                f"?accessToken={self._session.session_token}"
+        while self._pending_candidates and not self._closed and self._session:
+            _LOGGER.debug(
+                "Signaling relay: reconnecting to forward %d late ICE candidate(s)",
+                len(self._pending_candidates),
             )
-            ws = await websession.ws_connect(ws_url)
-            pending, self._pending_candidates = self._pending_candidates, []
-            sent = 0
             try:
-                for msg in pending:
-                    if self._closed:
-                        break
-                    await ws.send_json(msg)
-                    sent += 1
-                    _LOGGER.debug(
-                        "Signaling relay: forwarded late ICE candidate via reconnect"
-                    )
-            finally:
-                if sent < len(pending):
-                    self._pending_candidates = pending[sent:] + self._pending_candidates
-                await ws.close()
-        except Exception:
-            if not self._closed:
-                _LOGGER.debug(
-                    "Signaling relay: late ICE candidate reconnect failed",
-                    exc_info=True,
+                websession = self._client.websession
+                ws_url = (
+                    f"{self._session.signaling_url}"
+                    f"?accessToken={self._session.session_token}"
                 )
+                ws = await websession.ws_connect(ws_url)
+                pending, self._pending_candidates = self._pending_candidates, []
+                sent = 0
+                try:
+                    for msg in pending:
+                        await ws.send_json(msg)
+                        sent += 1
+                        _LOGGER.debug(
+                            "Signaling relay: forwarded late ICE candidate via reconnect"
+                        )
+                finally:
+                    if sent < len(pending):
+                        self._pending_candidates = (
+                            pending[sent:] + self._pending_candidates
+                        )
+                    await ws.close()
+            except Exception:
+                if not self._closed:
+                    _LOGGER.debug(
+                        "Signaling relay: late ICE candidate reconnect failed",
+                        exc_info=True,
+                    )
+                break
 
     async def _ping_loop(self) -> None:
         """Send periodic pings to keep the signaling connection alive."""
@@ -617,6 +621,8 @@ class CameraStream:
         """Start the WebRTC streaming session."""
         if self._stopped:
             raise CameraStreamException("Stream has been stopped")
+        if self._pc is not None:
+            raise CameraStreamException("Stream already started")
 
         self._session = await self._client.generate_session()
 
@@ -651,26 +657,36 @@ class CameraStream:
         self._pc.addTransceiver("video", direction="recvonly")
         self._pc.addTransceiver("audio", direction="recvonly")
 
-        websession = self._client.websession
-        ws_url = (
-            f"{self._session.signaling_url}?accessToken={self._session.session_token}"
-        )
-        self._ws = await websession.ws_connect(ws_url)
+        try:
+            websession = self._client.websession
+            ws_url = (
+                f"{self._session.signaling_url}"
+                f"?accessToken={self._session.session_token}"
+            )
+            self._ws = await websession.ws_connect(ws_url)
 
-        # setLocalDescription gathers ICE candidates internally.
-        # We must send localDescription.sdp (which includes all gathered
-        # candidates) rather than offer.sdp (which has none).
-        offer = await self._pc.createOffer()
-        await self._pc.setLocalDescription(offer)
+            # setLocalDescription gathers ICE candidates internally.
+            # We must send localDescription.sdp (which includes all gathered
+            # candidates) rather than offer.sdp (which has none).
+            offer = await self._pc.createOffer()
+            await self._pc.setLocalDescription(offer)
 
-        local_sdp = self._pc.localDescription.sdp
-        encoded_sdp = b64encode(local_sdp.encode()).decode()
-        await self._ws.send_json(
-            {
-                "type": "offer",
-                "sdp": encoded_sdp,
-            }
-        )
+            local_sdp = self._pc.localDescription.sdp
+            encoded_sdp = b64encode(local_sdp.encode()).decode()
+            await self._ws.send_json(
+                {
+                    "type": "offer",
+                    "sdp": encoded_sdp,
+                }
+            )
+        except Exception:
+            if self._ws and not self._ws.closed:
+                await self._ws.close()
+            if self._pc:
+                await self._pc.close()
+            self._ws = None
+            self._pc = None
+            raise
 
         self._receive_task = asyncio.ensure_future(self._receive_loop())
         self._ping_task = asyncio.ensure_future(self._ping_loop())

--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -1,0 +1,838 @@
+"""Camera support for Litter-Robot 5 Pro.
+
+Provides REST API access to camera sessions, settings, videos, and events
+via `CameraClient`, and WebRTC live streaming via `CameraStream`.
+
+WebRTC streaming requires the optional ``aiortc`` dependency::
+
+    pip install pylitterbot[camera]
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from base64 import b64decode, b64encode
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Callable
+
+from aiohttp import ClientResponseError, ClientSession, WSMsgType
+
+from .exceptions import CameraStreamException
+from .utils import to_timestamp
+
+if TYPE_CHECKING:
+    from .session import Session
+
+_LOGGER = logging.getLogger(__name__)
+
+WATFORD_API = "https://watford.ienso-dev.com"
+CAMERA_SETTINGS_API = "https://7mnuil943l.execute-api.us-east-1.amazonaws.com"
+CAMERA_INVENTORY_API = "https://rrntg65uwf.execute-api.us-east-1.amazonaws.com"
+
+CAMERA_CANVAS_FRONT = "sensor_0_1080p"
+CAMERA_CANVAS_GLOBE = "sensor_1_720p"
+CAMERA_CANVAS_LABELS: dict[str, str] = {
+    CAMERA_CANVAS_FRONT: "Front Camera (1080p)",
+    CAMERA_CANVAS_GLOBE: "Globe Camera (720p)",
+}
+
+GENERATE_SESSION_PATH = "api/device-manager/client/generate-session"
+SIGNALING_PATH = "api/signaling"
+
+PING_INTERVAL = 5  # seconds -- ping frequently to prevent server idle timeout (~18s)
+
+
+@dataclass
+class CameraSession:
+    """Represents a camera streaming session with TURN credentials."""
+
+    session_id: str
+    session_token: str
+    session_expiration: datetime | None
+    signaling_url: str
+    turn_servers: list[dict[str, Any]] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_response(cls, data: dict[str, Any]) -> CameraSession:
+        """Create a CameraSession from the generate-session API response."""
+        session_token = data.get("sessionToken", "")
+
+        turn_creds = (
+            data.get("turnServer")
+            or data.get("turnCredentials")
+            or data.get("iceServers")
+            or []
+        )
+        if isinstance(turn_creds, dict):
+            turn_creds = [turn_creds]
+
+        signaling_url = data.get("signalingURL", "")
+        if not signaling_url:
+            ws_base = WATFORD_API.replace("https://", "wss://")
+            signaling_url = f"{ws_base}/{SIGNALING_PATH}"
+
+        return cls(
+            session_id=data.get("sessionId", ""),
+            session_token=session_token,
+            session_expiration=to_timestamp(data.get("sessionExpiration")),
+            signaling_url=signaling_url,
+            turn_servers=turn_creds,
+            raw=data,
+        )
+
+
+@dataclass
+class VideoClip:
+    """Represents a recorded camera video clip."""
+
+    id: str
+    thumbnail_url: str | None
+    event_type: str | None
+    created_at: datetime | None
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @classmethod
+    def from_response(cls, data: dict[str, Any]) -> VideoClip:
+        """Create a VideoClip from an API response item."""
+        return cls(
+            id=str(data.get("id", "")),
+            thumbnail_url=data.get("videoThumbnail"),
+            event_type=data.get("eventType"),
+            created_at=to_timestamp(data.get("createdAt")),
+            raw=data,
+        )
+
+
+class CameraClient:
+    """REST client for LR5 Pro camera APIs.
+
+    Uses the account session for Bearer token auth.  Camera settings and
+    inventory endpoints additionally require an ``x-api-key`` header.
+    """
+
+    def __init__(
+        self,
+        session: Session,
+        device_id: str,
+        *,
+        api_key: str | None = None,
+    ) -> None:
+        """Initialize the camera client.
+
+        Args:
+            session: The authenticated pylitterbot session.
+            device_id: The camera ``deviceId`` from robot ``cameraMetadata``.
+            api_key: Optional x-api-key for settings/inventory endpoints.
+
+        """
+        self._session = session
+        self._device_id = device_id
+        self._api_key = api_key
+        self._settings_base = f"{CAMERA_SETTINGS_API}/prod/v1/cameras/{device_id}"
+        self._inventory_base = f"{CAMERA_INVENTORY_API}/prod/v1/cameras/{device_id}"
+
+    @property
+    def device_id(self) -> str:
+        """Return the camera device id."""
+        return self._device_id
+
+    @property
+    def websession(self) -> ClientSession:
+        """Return the underlying aiohttp client session."""
+        return self._session.websession
+
+    def _settings_headers(self) -> dict[str, str]:
+        """Return extra headers for camera settings/inventory endpoints."""
+        headers: dict[str, str] = {}
+        if self._api_key:
+            headers["x-api-key"] = self._api_key
+        return headers
+
+    async def generate_session(self, *, auto_start: bool = True) -> CameraSession:
+        """Create a camera streaming session.
+
+        Returns TURN credentials and a signaling websocket URL.
+        """
+        url = f"{WATFORD_API}/{GENERATE_SESSION_PATH}/{self._device_id}"
+        data = await self._session.get(
+            url,
+            params={"autoStart": "true" if auto_start else "false"},
+        )
+        if not isinstance(data, dict):
+            raise CameraStreamException(
+                "Failed to generate camera session: unexpected response"
+            )
+        return CameraSession.from_response(data)
+
+    async def get_video_settings(
+        self, settings_type: str = "videoSettings"
+    ) -> dict[str, Any] | None:
+        """Fetch reported video settings for the camera."""
+        url = f"{self._settings_base}/reported-settings/{settings_type}"
+        try:
+            data = await self._session.get(url, headers=self._settings_headers())
+        except ClientResponseError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    async def set_camera_canvas(self, canvas: str) -> bool:
+        """Set the live-view canvas (camera view selection).
+
+        Args:
+            canvas: One of ``CAMERA_CANVAS_FRONT`` or ``CAMERA_CANVAS_GLOBE``.
+
+        """
+        from .utils import utcnow
+
+        url = f"{self._settings_base}/desired-settings/videoSettings"
+        payload = {
+            "streams": {"live-view": {"canvas": canvas}},
+            "timestamp": utcnow().strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        }
+        try:
+            await self._session.patch(
+                url, json=payload, headers=self._settings_headers()
+            )
+            return True
+        except ClientResponseError:
+            return False
+
+    async def set_audio_enabled(self, enabled: bool) -> bool:
+        """Enable or disable the camera microphone.
+
+        Args:
+            enabled: ``True`` to unmute, ``False`` to mute.
+
+        """
+        url = f"{self._settings_base}/desired-settings/audioSettings"
+        payload = {
+            "audio_in": {"global": {"mute": not enabled}},
+        }
+        try:
+            await self._session.patch(
+                url, json=payload, headers=self._settings_headers()
+            )
+            return True
+        except ClientResponseError:
+            return False
+
+    async def get_audio_settings(self) -> dict[str, Any] | None:
+        """Fetch reported audio settings for the camera."""
+        url = f"{self._settings_base}/reported-settings/audioSettings"
+        try:
+            data = await self._session.get(url, headers=self._settings_headers())
+        except ClientResponseError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    async def get_camera_info(self) -> dict[str, Any] | None:
+        """Fetch camera device information from the inventory API."""
+        url = self._inventory_base
+        try:
+            data = await self._session.get(url, headers=self._settings_headers())
+        except ClientResponseError:
+            return None
+        return data if isinstance(data, dict) else None
+
+    async def get_videos(
+        self, *, date: str | None = None, limit: int | None = None
+    ) -> list[VideoClip]:
+        """Fetch recorded video clips.
+
+        Args:
+            date: Optional date string (YYYY-MM-DD) to filter videos.
+            limit: Optional max number of results.
+
+        """
+        parts = [f"{self._inventory_base}/videos"]
+        if date:
+            parts.append(f"/{date}")
+        url = "".join(parts)
+        params: dict[str, str] = {}
+        if limit is not None:
+            params["limit"] = str(limit)
+        try:
+            data = await self._session.get(
+                url,
+                headers=self._settings_headers(),
+                params=params or None,
+            )
+        except ClientResponseError:
+            return []
+        if not isinstance(data, list):
+            return []
+        return [
+            VideoClip.from_response(item) for item in data if isinstance(item, dict)
+        ]
+
+    async def get_events(self, *, limit: int | None = None) -> list[dict[str, Any]]:
+        """Fetch camera events (AI detections, etc.).
+
+        Args:
+            limit: Optional max number of results.
+
+        """
+        url = f"{self._inventory_base}/events"
+        params: dict[str, str] = {}
+        if limit is not None:
+            params["limit"] = str(limit)
+        try:
+            data = await self._session.get(
+                url,
+                headers=self._settings_headers(),
+                params=params or None,
+            )
+        except ClientResponseError:
+            return []
+        if not isinstance(data, list):
+            return []
+        return [item for item in data if isinstance(item, dict)]
+
+
+class CameraSignalingRelay:
+    """Signaling relay for browser-to-camera WebRTC.
+
+    Unlike ``CameraStream`` (which creates its own RTCPeerConnection via
+    aiortc), this class only handles signaling -- forwarding SDP and ICE
+    candidates between the browser and camera via the Watford signaling
+    WebSocket. Designed for HA's camera platform where the browser is the
+    WebRTC peer.
+    """
+
+    def __init__(self, client: CameraClient) -> None:
+        """Initialize the signaling relay.
+
+        Args:
+            client: A ``CameraClient`` instance.
+
+        """
+        self._client = client
+        self._session: CameraSession | None = None
+        self._ws: Any | None = None  # aiohttp ClientWebSocketResponse
+        self._ping_task: asyncio.Task[None] | None = None
+        self._receive_task: asyncio.Task[None] | None = None
+        self._closed = False
+        self._pending_candidates: list[dict[str, Any]] = []
+        self._reconnect_task: asyncio.Task[None] | None = None
+
+    @property
+    def session(self) -> CameraSession | None:
+        """Return the current camera session."""
+        return self._session
+
+    async def start(
+        self,
+        offer_sdp: str,
+        on_answer: Callable[[str], None],
+        on_candidate: Callable[[dict[str, Any]], None],
+    ) -> CameraSession:
+        """Connect to signaling WS, send offer, relay answer and ICE candidates.
+
+        Args:
+            offer_sdp: The browser's SDP offer (plain text, not base64).
+            on_answer: Called with the decoded SDP answer from the camera.
+            on_candidate: Called with ICE candidate dicts from the camera.
+
+        Returns:
+            The ``CameraSession`` with TURN credentials.
+
+        """
+        if self._closed:
+            raise CameraStreamException("Relay has been closed")
+
+        self._session = await self._client.generate_session()
+
+        websession = self._client.websession
+        ws_url = (
+            f"{self._session.signaling_url}?accessToken={self._session.session_token}"
+        )
+        self._ws = await websession.ws_connect(ws_url)
+
+        encoded_sdp = b64encode(offer_sdp.encode()).decode()
+        _LOGGER.debug("Signaling relay: sending offer (%d bytes)", len(offer_sdp))
+        await self._ws.send_json({"type": "offer", "sdp": encoded_sdp})
+
+        if self._pending_candidates:
+            _LOGGER.debug(
+                "Signaling relay: flushing %d buffered ICE candidates",
+                len(self._pending_candidates),
+            )
+            for msg in self._pending_candidates:
+                await self._ws.send_json(msg)
+            self._pending_candidates.clear()
+
+        self._receive_task = asyncio.ensure_future(
+            self._receive_loop(on_answer, on_candidate)
+        )
+        self._ping_task = asyncio.ensure_future(self._ping_loop())
+
+        return self._session
+
+    async def send_candidate(self, candidate: dict[str, Any]) -> None:
+        """Forward a browser ICE candidate to the camera.
+
+        If the signaling WebSocket is not yet connected, the candidate is
+        buffered and will be flushed once ``start()`` completes.
+
+        Args:
+            candidate: ICE candidate dict with ``candidate``, ``sdpMid``,
+                and ``sdpMLineIndex`` keys.
+
+        """
+        msg = {
+            "type": "candidate",
+            "candidate": candidate.get("candidate", ""),
+            "sdpMid": candidate.get("sdpMid", "0"),
+            "sdpMLineIndex": candidate.get("sdpMLineIndex", 0),
+        }
+        if self._ws and not self._ws.closed:
+            try:
+                await self._ws.send_json(msg)
+                return
+            except Exception:
+                _LOGGER.debug(
+                    "Signaling relay: send failed -- buffering ICE candidate for reconnect",
+                    exc_info=True,
+                )
+
+        _LOGGER.debug(
+            "Signaling relay: WS closed -- buffering ICE candidate for reconnect"
+        )
+        self._pending_candidates.append(msg)
+        if (
+            self._session
+            and not self._closed
+            and (self._reconnect_task is None or self._reconnect_task.done())
+        ):
+            self._reconnect_task = asyncio.ensure_future(self._reconnect_and_flush())
+
+    async def close(self) -> None:
+        """Cancel tasks and close the signaling WebSocket."""
+        self._closed = True
+
+        for task in filter(
+            None, [self._ping_task, self._receive_task, self._reconnect_task]
+        ):
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+
+    async def _receive_loop(
+        self,
+        on_answer: Callable[[str], None],
+        on_candidate: Callable[[dict[str, Any]], None],
+    ) -> None:
+        """Receive messages from the signaling WebSocket and relay them."""
+        _LOGGER.debug("Signaling relay: receive loop started")
+        try:
+            async for msg in self._ws:  # type: ignore[union-attr]
+                if self._closed:
+                    break
+                _LOGGER.debug("Signaling relay: received msg type=%s", msg.type)
+                if msg.type == WSMsgType.TEXT:
+                    data = msg.json()
+                    msg_type = data.get("type", "")
+                    _LOGGER.debug(
+                        "Signaling relay: message type=%s keys=%s",
+                        msg_type,
+                        list(data.keys()),
+                    )
+
+                    if msg_type == "answer":
+                        raw_sdp = data.get("payload") or data.get("sdp", "")
+                        try:
+                            sdp = b64decode(raw_sdp).decode()
+                        except Exception:
+                            sdp = raw_sdp
+                        _LOGGER.debug(
+                            "Signaling relay: received answer (%d bytes)",
+                            len(sdp),
+                        )
+                        on_answer(sdp)
+
+                    elif msg_type == "candidate" or "candidate" in data:
+                        candidate_str = data.get("candidate", "")
+                        if candidate_str:
+                            _LOGGER.debug("Signaling relay: received ICE candidate")
+                            on_candidate(
+                                {
+                                    "candidate": candidate_str,
+                                    "sdpMid": data.get("sdpMid", "0"),
+                                    "sdpMLineIndex": data.get("sdpMLineIndex", 0),
+                                }
+                            )
+
+                elif msg.type in (WSMsgType.CLOSED, WSMsgType.ERROR):
+                    _LOGGER.debug("Signaling relay: WS closed/error type=%s", msg.type)
+                    break
+            _LOGGER.debug("Signaling relay: receive loop ended")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if not self._closed:
+                _LOGGER.exception("Signaling relay receive error")
+
+    async def _reconnect_and_flush(self) -> None:
+        """Reconnect to the signaling WebSocket to forward late browser ICE candidates.
+
+        After the camera sends its answer and ICE candidates, the Watford server
+        closes the WebSocket.  Browser ICE candidates that arrive after closure are
+        buffered here and delivered via a fresh connection to the same session URL,
+        allowing the camera to complete ICE negotiation.
+        """
+        if not self._session or not self._pending_candidates:
+            return
+        _LOGGER.debug(
+            "Signaling relay: reconnecting to forward %d late ICE candidate(s)",
+            len(self._pending_candidates),
+        )
+        try:
+            websession = self._client.websession
+            ws_url = (
+                f"{self._session.signaling_url}"
+                f"?accessToken={self._session.session_token}"
+            )
+            ws = await websession.ws_connect(ws_url)
+            pending, self._pending_candidates = self._pending_candidates, []
+            sent = 0
+            try:
+                for msg in pending:
+                    if self._closed:
+                        break
+                    await ws.send_json(msg)
+                    sent += 1
+                    _LOGGER.debug(
+                        "Signaling relay: forwarded late ICE candidate via reconnect"
+                    )
+            finally:
+                if sent < len(pending):
+                    self._pending_candidates = pending[sent:] + self._pending_candidates
+                await ws.close()
+        except Exception:
+            if not self._closed:
+                _LOGGER.debug(
+                    "Signaling relay: late ICE candidate reconnect failed",
+                    exc_info=True,
+                )
+
+    async def _ping_loop(self) -> None:
+        """Send periodic pings to keep the signaling connection alive."""
+        try:
+            while not self._closed:
+                await asyncio.sleep(PING_INTERVAL)
+                if self._ws and not self._ws.closed:
+                    await self._ws.ping()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if not self._closed:
+                _LOGGER.debug("Relay ping loop ended")
+
+
+try:
+    from aiortc import (
+        RTCConfiguration,
+        RTCIceServer,
+        RTCPeerConnection,
+        RTCSessionDescription,
+    )
+    from aiortc.sdp import candidate_from_sdp
+
+    HAS_AIORTC = True
+except ImportError:
+    HAS_AIORTC = False
+
+
+class CameraStream:
+    """WebRTC live stream for an LR5 Pro camera.
+
+    Requires the ``aiortc`` package.  Install with::
+
+        pip install pylitterbot[camera]
+
+    Usage::
+
+        async with CameraStream(camera_client) as stream:
+            stream.on_video_frame(my_video_handler)
+            await stream.wait_for_connection()
+            # ... frames delivered via callback ...
+    """
+
+    def __init__(self, client: CameraClient, **kwargs: Any) -> None:
+        """Initialize the camera stream.
+
+        Args:
+            client: A ``CameraClient`` instance.
+            **kwargs: Extra keyword arguments (reserved for future use).
+
+        Raises:
+            ImportError: If ``aiortc`` is not installed.
+
+        """
+        if not HAS_AIORTC:
+            raise ImportError(
+                "CameraStream requires the 'aiortc' package. "
+                "Install it with: pip install pylitterbot[camera]"
+            )
+
+        self._client = client
+        self._kwargs = kwargs
+
+        self._session: CameraSession | None = None
+        self._pc: RTCPeerConnection | None = None
+        self._ws: Any | None = None  # aiohttp ClientWebSocketResponse
+        self._ping_task: asyncio.Task[None] | None = None
+        self._receive_task: asyncio.Task[None] | None = None
+        self._media_tasks: list[asyncio.Task[None]] = []
+
+        self._video_callback: Callable | None = None
+        self._audio_callback: Callable | None = None
+        self._state_callback: Callable | None = None
+
+        self._connected = asyncio.Event()
+        self._stopped = False
+
+    def on_video_frame(self, callback: Callable) -> None:
+        """Register a callback for incoming video frames."""
+        self._video_callback = callback
+
+    def on_audio_frame(self, callback: Callable) -> None:
+        """Register a callback for incoming audio frames."""
+        self._audio_callback = callback
+
+    def on_connection_state_change(self, callback: Callable) -> None:
+        """Register a callback for peer connection state changes."""
+        self._state_callback = callback
+
+    async def start(self) -> None:
+        """Start the WebRTC streaming session."""
+        if self._stopped:
+            raise CameraStreamException("Stream has been stopped")
+
+        self._session = await self._client.generate_session()
+
+        ice_servers = self._build_ice_servers(self._session.turn_servers)
+
+        config = RTCConfiguration(iceServers=ice_servers)
+        self._pc = RTCPeerConnection(configuration=config)
+
+        @self._pc.on("track")
+        def on_track(track: Any) -> None:
+            _LOGGER.debug("Received %s track: %s", track.kind, track.id)
+            if track.kind == "video" and self._video_callback:
+                task = asyncio.ensure_future(
+                    self._consume_track(track, self._video_callback)
+                )
+                self._media_tasks.append(task)
+            elif track.kind == "audio" and self._audio_callback:
+                task = asyncio.ensure_future(
+                    self._consume_track(track, self._audio_callback)
+                )
+                self._media_tasks.append(task)
+
+        @self._pc.on("connectionstatechange")
+        async def on_state_change() -> None:
+            state = self._pc.connectionState  # type: ignore[union-attr]
+            _LOGGER.debug("Connection state: %s", state)
+            if state in ("connected", "completed"):
+                self._connected.set()
+            if self._state_callback:
+                self._state_callback(state)
+
+        self._pc.addTransceiver("video", direction="recvonly")
+        self._pc.addTransceiver("audio", direction="recvonly")
+
+        websession = self._client.websession
+        ws_url = (
+            f"{self._session.signaling_url}?accessToken={self._session.session_token}"
+        )
+        self._ws = await websession.ws_connect(ws_url)
+
+        # setLocalDescription gathers ICE candidates internally.
+        # We must send localDescription.sdp (which includes all gathered
+        # candidates) rather than offer.sdp (which has none).
+        offer = await self._pc.createOffer()
+        await self._pc.setLocalDescription(offer)
+
+        local_sdp = self._pc.localDescription.sdp
+        encoded_sdp = b64encode(local_sdp.encode()).decode()
+        await self._ws.send_json(
+            {
+                "type": "offer",
+                "sdp": encoded_sdp,
+            }
+        )
+
+        self._receive_task = asyncio.ensure_future(self._receive_loop())
+        self._ping_task = asyncio.ensure_future(self._ping_loop())
+
+    async def stop(self) -> None:
+        """Stop the WebRTC streaming session and clean up resources."""
+        self._stopped = True
+
+        for task in self._media_tasks:
+            if not task.done():
+                task.cancel()
+        for task in self._media_tasks:
+            if not task.done():
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        self._media_tasks.clear()
+
+        if self._ping_task and not self._ping_task.done():
+            self._ping_task.cancel()
+            try:
+                await self._ping_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._receive_task and not self._receive_task.done():
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._ws and not self._ws.closed:
+            await self._ws.close()
+
+        if self._pc:
+            await self._pc.close()
+
+    async def wait_for_connection(self, timeout: float = 30) -> bool:
+        """Wait until the WebRTC connection is established.
+
+        Args:
+            timeout: Maximum seconds to wait.
+
+        Returns:
+            True if connected, False if timed out.
+
+        """
+        try:
+            await asyncio.wait_for(self._connected.wait(), timeout=timeout)
+            return True
+        except asyncio.TimeoutError:
+            return False
+
+    async def __aenter__(self) -> CameraStream:
+        """Start the stream on context entry."""
+        await self.start()
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        """Stop the stream on context exit."""
+        await self.stop()
+
+    @staticmethod
+    def _build_ice_servers(
+        turn_creds: list[dict[str, Any]],
+    ) -> list[Any]:
+        """Convert TURN credentials to RTCIceServer objects."""
+        servers: list[RTCIceServer] = [
+            RTCIceServer(urls="stun:stun.l.google.com:19302"),
+        ]
+        for cred in turn_creds:
+            urls = cred.get("turnUrl") or cred.get("urls") or cred.get("uris") or []
+            if isinstance(urls, str):
+                urls = [urls]
+            if urls:
+                servers.append(
+                    RTCIceServer(
+                        urls=urls,
+                        username=cred.get("username", ""),
+                        credential=cred.get("password") or cred.get("credential", ""),
+                    )
+                )
+            stun_url = cred.get("stunUrl")
+            if stun_url and not any(
+                stun_url == s.urls or stun_url in s.urls for s in servers
+            ):
+                servers.append(RTCIceServer(urls=stun_url))
+        return servers
+
+    async def _consume_track(self, track: Any, callback: Callable) -> None:
+        """Read frames from a media track and deliver via callback."""
+        try:
+            while not self._stopped:
+                frame = await track.recv()
+                try:
+                    callback(frame)
+                except Exception:
+                    _LOGGER.exception("Error in frame callback")
+        except Exception:
+            if not self._stopped:
+                _LOGGER.debug("Track %s ended", track.kind)
+
+    async def _receive_loop(self) -> None:
+        """Receive messages from the signaling websocket."""
+        try:
+            async for msg in self._ws:  # type: ignore[union-attr]
+                if self._stopped:
+                    break
+                if msg.type == WSMsgType.TEXT:
+                    await self._handle_signaling_message(msg.json())
+                elif msg.type in (WSMsgType.CLOSED, WSMsgType.ERROR):
+                    break
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if not self._stopped:
+                _LOGGER.exception("Signaling receive error")
+
+    async def _handle_signaling_message(self, data: dict[str, Any]) -> None:
+        """Handle an incoming signaling message (answer or ICE candidate)."""
+        msg_type = data.get("type", "")
+
+        if msg_type == "answer":
+            raw_sdp = data.get("payload") or data.get("sdp", "")
+            try:
+                sdp = b64decode(raw_sdp).decode()
+            except Exception:
+                sdp = raw_sdp
+
+            answer = RTCSessionDescription(sdp=sdp, type="answer")
+            await self._pc.setRemoteDescription(answer)  # type: ignore[union-attr]
+            _LOGGER.debug("Set remote description (answer)")
+
+        elif msg_type == "candidate" or "candidate" in data:
+            candidate_str = data.get("candidate", "")
+            if not candidate_str:
+                return
+            sdp_mid = data.get("sdpMid", "0")
+            sdp_mline_index = data.get("sdpMLineIndex", 0)
+
+            try:
+                candidate = candidate_from_sdp(candidate_str)
+                candidate.sdpMid = sdp_mid
+                candidate.sdpMLineIndex = sdp_mline_index
+            except Exception:
+                _LOGGER.warning("Failed to parse ICE candidate: %s", candidate_str[:80])
+                return
+
+            await self._pc.addIceCandidate(candidate)  # type: ignore[union-attr]
+            _LOGGER.debug("Added ICE candidate: %s", candidate_str[:60])
+
+    async def _ping_loop(self) -> None:
+        """Send periodic pings to keep the signaling connection alive."""
+        try:
+            while not self._stopped:
+                await asyncio.sleep(PING_INTERVAL)
+                if self._ws and not self._ws.closed:
+                    await self._ws.ping()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if not self._stopped:
+                _LOGGER.debug("Ping loop ended")

--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -12,10 +12,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from base64 import b64decode, b64encode
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable
+from urllib.parse import quote
 
 from aiohttp import (
     ClientResponseError,
@@ -24,8 +24,10 @@ from aiohttp import (
     WSMsgType,
 )
 
-from .exceptions import CameraStreamException
-from .utils import to_timestamp, utcnow
+from .exceptions import CameraStreamException, InvalidCommandException
+from .session import DEFAULT_USER_AGENT
+from .transport import cancel_task
+from .utils import decode, encode, first_value, to_timestamp, utcnow
 
 if TYPE_CHECKING:
     from .session import Session
@@ -38,15 +40,60 @@ CAMERA_INVENTORY_API = "https://rrntg65uwf.execute-api.us-east-1.amazonaws.com"
 
 CAMERA_CANVAS_FRONT = "sensor_0_1080p"
 CAMERA_CANVAS_GLOBE = "sensor_1_720p"
-CAMERA_CANVAS_LABELS: dict[str, str] = {
-    CAMERA_CANVAS_FRONT: "Front Camera (1080p)",
-    CAMERA_CANVAS_GLOBE: "Globe Camera (720p)",
-}
 
 GENERATE_SESSION_PATH = "api/device-manager/client/generate-session"
 SIGNALING_PATH = "api/signaling"
+FALLBACK_STUN_URL = "stun:stun.l.google.com:19302"
 
 PING_INTERVAL = 5  # seconds -- ping frequently to prevent server idle timeout (~18s)
+MAX_PENDING_CANDIDATES = 50
+
+# session.request converts HTTP 500 responses into InvalidCommandException, so
+# graceful-fallback handling must catch it alongside other client errors.
+_API_ERRORS = (ClientResponseError, InvalidCommandException)
+
+_WS_HEADERS = {"User-Agent": DEFAULT_USER_AGENT}
+
+
+def _decode_sdp(raw_sdp: str) -> str:
+    """Return the SDP from a signaling payload that may be base64-encoded."""
+    try:
+        decoded = decode(raw_sdp)
+        if decoded.strip().startswith("v="):
+            return decoded
+    except (TypeError, ValueError):
+        _LOGGER.debug("Signaling: SDP not base64-encoded, using raw")
+    return raw_sdp
+
+
+def _parse_signaling_message(data: dict[str, Any]) -> tuple[str, Any] | None:
+    """Parse a signaling message into ``("answer", sdp)`` or ``("candidate", dict)``.
+
+    Returns ``None`` for messages that carry neither. Explicit JSON ``null``
+    values for ``sdpMid``/``sdpMLineIndex`` are normalized to their defaults
+    (``dict.get`` defaults do not apply to present-but-null keys).
+    """
+    msg_type = data.get("type", "")
+
+    if msg_type == "answer":
+        raw_sdp = data.get("payload") or data.get("sdp", "")
+        return ("answer", _decode_sdp(raw_sdp))
+
+    if msg_type == "candidate" or "candidate" in data:
+        if not (candidate := data.get("candidate", "")):
+            return None
+        sdp_mid = data.get("sdpMid")
+        sdp_mline_index = data.get("sdpMLineIndex")
+        return (
+            "candidate",
+            {
+                "candidate": candidate,
+                "sdpMid": "0" if sdp_mid is None else sdp_mid,
+                "sdpMLineIndex": 0 if sdp_mline_index is None else sdp_mline_index,
+            },
+        )
+
+    return None
 
 
 @dataclass
@@ -60,16 +107,16 @@ class CameraSession:
     turn_servers: list[dict[str, Any]] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict, repr=False)
 
+    @property
+    def ws_url(self) -> str:
+        """Return the signaling websocket URL with the URL-encoded session token."""
+        return f"{self.signaling_url}?accessToken={quote(self.session_token, safe='')}"
+
     @classmethod
     def from_response(cls, data: dict[str, Any]) -> CameraSession:
         """Create a CameraSession from the generate-session API response."""
-        session_token = data.get("sessionToken", "")
-
         turn_creds = (
-            data.get("turnServer")
-            or data.get("turnCredentials")
-            or data.get("iceServers")
-            or []
+            first_value(data, ("turnServer", "turnCredentials", "iceServers")) or []
         )
         if isinstance(turn_creds, dict):
             turn_creds = [turn_creds]
@@ -81,7 +128,7 @@ class CameraSession:
 
         return cls(
             session_id=data.get("sessionId", ""),
-            session_token=session_token,
+            session_token=data.get("sessionToken", ""),
             session_expiration=to_timestamp(data.get("sessionExpiration")),
             signaling_url=signaling_url,
             turn_servers=turn_creds,
@@ -156,16 +203,46 @@ class CameraClient:
             headers["x-api-key"] = self._api_key
         return headers
 
+    async def _get(self, url: str, **kwargs: Any) -> Any | None:
+        """GET a camera endpoint, returning ``None`` on API failure."""
+        try:
+            return await self._session.get(
+                url, headers=self._settings_headers(), **kwargs
+            )
+        except _API_ERRORS as err:
+            _LOGGER.debug("Camera GET %s failed: %s", url, err)
+            return None
+
+    async def _patch(self, url: str, payload: dict[str, Any]) -> bool:
+        """PATCH a camera endpoint, returning ``False`` on API failure."""
+        try:
+            await self._session.patch(
+                url, json=payload, headers=self._settings_headers()
+            )
+        except _API_ERRORS as err:
+            _LOGGER.debug("Camera PATCH %s failed: %s", url, err)
+            return False
+        return True
+
     async def generate_session(self, *, auto_start: bool = True) -> CameraSession:
         """Create a camera streaming session.
 
         Returns TURN credentials and a signaling websocket URL.
+
+        Raises:
+            CameraStreamException: If the session could not be generated.
+
         """
         url = f"{WATFORD_API}/{GENERATE_SESSION_PATH}/{self._device_id}"
-        data = await self._session.get(
-            url,
-            params={"autoStart": "true" if auto_start else "false"},
-        )
+        try:
+            data = await self._session.get(
+                url,
+                params={"autoStart": "true" if auto_start else "false"},
+            )
+        except _API_ERRORS as err:
+            raise CameraStreamException(
+                f"Failed to generate camera session for {self._device_id}: {err}"
+            ) from err
         if not isinstance(data, dict):
             raise CameraStreamException(
                 "Failed to generate camera session: unexpected response"
@@ -175,14 +252,20 @@ class CameraClient:
     async def get_video_settings(
         self, settings_type: str = "videoSettings"
     ) -> dict[str, Any] | None:
-        """Fetch reported video settings for the camera."""
+        """Fetch reported video settings for the camera.
+
+        The endpoint wraps each settings document in a ``reportedSettings``
+        list; the inner ``data`` dict for the requested type is returned.
+        """
         url = f"{self._settings_base}/reported-settings/{settings_type}"
-        try:
-            data = await self._session.get(url, headers=self._settings_headers())
-        except ClientResponseError as err:
-            _LOGGER.debug("get_video_settings failed: %s", err)
+        data = await self._get(url)
+        if not isinstance(data, dict):
             return None
-        return data if isinstance(data, dict) else None
+        for item in data.get("reportedSettings", []):
+            if isinstance(item, dict) and item.get("settingsType") == settings_type:
+                inner = item.get("data")
+                return inner if isinstance(inner, dict) else None
+        return None
 
     async def set_camera_canvas(self, canvas: str) -> bool:
         """Set the live-view canvas (camera view selection).
@@ -196,14 +279,7 @@ class CameraClient:
             "streams": {"live-view": {"canvas": canvas}},
             "timestamp": utcnow().strftime("%Y-%m-%dT%H:%M:%S.000Z"),
         }
-        try:
-            await self._session.patch(
-                url, json=payload, headers=self._settings_headers()
-            )
-            return True
-        except ClientResponseError as err:
-            _LOGGER.debug("set_camera_canvas failed: %s", err)
-            return False
+        return await self._patch(url, payload)
 
     async def set_audio_enabled(self, enabled: bool) -> bool:
         """Enable or disable the camera microphone.
@@ -216,33 +292,15 @@ class CameraClient:
         payload = {
             "audio_in": {"global": {"mute": not enabled}},
         }
-        try:
-            await self._session.patch(
-                url, json=payload, headers=self._settings_headers()
-            )
-            return True
-        except ClientResponseError as err:
-            _LOGGER.debug("set_audio_enabled failed: %s", err)
-            return False
+        return await self._patch(url, payload)
 
     async def get_audio_settings(self) -> dict[str, Any] | None:
         """Fetch reported audio settings for the camera."""
-        url = f"{self._settings_base}/reported-settings/audioSettings"
-        try:
-            data = await self._session.get(url, headers=self._settings_headers())
-        except ClientResponseError as err:
-            _LOGGER.debug("get_audio_settings failed: %s", err)
-            return None
-        return data if isinstance(data, dict) else None
+        return await self.get_video_settings("audioSettings")
 
     async def get_camera_info(self) -> dict[str, Any] | None:
         """Fetch camera device information from the inventory API."""
-        url = self._inventory_base
-        try:
-            data = await self._session.get(url, headers=self._settings_headers())
-        except ClientResponseError as err:
-            _LOGGER.debug("get_camera_info failed: %s", err)
-            return None
+        data = await self._get(self._inventory_base)
         return data if isinstance(data, dict) else None
 
     async def get_videos(
@@ -255,22 +313,9 @@ class CameraClient:
             limit: Optional max number of results.
 
         """
-        parts = [f"{self._inventory_base}/videos"]
-        if date:
-            parts.append(f"/{date}")
-        url = "".join(parts)
-        params: dict[str, str] = {}
-        if limit is not None:
-            params["limit"] = str(limit)
-        try:
-            data = await self._session.get(
-                url,
-                headers=self._settings_headers(),
-                params=params or None,
-            )
-        except ClientResponseError as err:
-            _LOGGER.debug("get_videos failed: %s", err)
-            return []
+        url = f"{self._inventory_base}/videos" + (f"/{date}" if date else "")
+        params = {"limit": str(limit)} if limit is not None else None
+        data = await self._get(url, params=params)
         if not isinstance(data, list):
             return []
         clips = [
@@ -286,25 +331,40 @@ class CameraClient:
 
         """
         url = f"{self._inventory_base}/events"
-        params: dict[str, str] = {}
-        if limit is not None:
-            params["limit"] = str(limit)
-        try:
-            data = await self._session.get(
-                url,
-                headers=self._settings_headers(),
-                params=params or None,
-            )
-        except ClientResponseError as err:
-            _LOGGER.debug("get_events failed: %s", err)
-            return []
+        params = {"limit": str(limit)} if limit is not None else None
+        data = await self._get(url, params=params)
         if not isinstance(data, list):
             return []
         events = [item for item in data if isinstance(item, dict)]
         return events[:limit] if limit is not None else events
 
 
-class CameraSignalingRelay:
+class _SignalingMixin:
+    """Shared signaling-websocket plumbing for relay and stream classes."""
+
+    _ws: ClientWebSocketResponse | None
+
+    @property
+    def _finished(self) -> bool:
+        """Return `True` once the owner has been closed/stopped."""
+        raise NotImplementedError
+
+    async def _ping_loop(self) -> None:
+        """Send periodic pings to keep the signaling connection alive."""
+        try:
+            while not self._finished:
+                await asyncio.sleep(PING_INTERVAL)
+                if self._ws is None or self._ws.closed:
+                    break
+                await self._ws.ping()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            if not self._finished:
+                _LOGGER.debug("Signaling ping loop ended", exc_info=True)
+
+
+class CameraSignalingRelay(_SignalingMixin):
     """Signaling relay for browser-to-camera WebRTC.
 
     Unlike ``CameraStream`` (which creates its own RTCPeerConnection via
@@ -327,8 +387,13 @@ class CameraSignalingRelay:
         self._ping_task: asyncio.Task[None] | None = None
         self._receive_task: asyncio.Task[None] | None = None
         self._closed = False
+        self._started = False
         self._pending_candidates: list[dict[str, Any]] = []
         self._reconnect_task: asyncio.Task[None] | None = None
+
+    @property
+    def _finished(self) -> bool:
+        return self._closed
 
     @property
     def session(self) -> CameraSession | None:
@@ -351,6 +416,10 @@ class CameraSignalingRelay:
         Returns:
             The ``CameraSession`` with TURN credentials.
 
+        Raises:
+            CameraStreamException: If the relay is closed/started or the
+                camera session could not be generated.
+
         """
         if self._closed:
             raise CameraStreamException("Relay has been closed")
@@ -361,12 +430,12 @@ class CameraSignalingRelay:
 
         try:
             websession = self._client.websession
-            ws_url = f"{self._session.signaling_url}?accessToken={self._session.session_token}"
-            self._ws = await websession.ws_connect(ws_url)
+            self._ws = await websession.ws_connect(
+                self._session.ws_url, headers=_WS_HEADERS
+            )
 
-            encoded_sdp = b64encode(offer_sdp.encode()).decode()
             _LOGGER.debug("Signaling relay: sending offer (%d bytes)", len(offer_sdp))
-            await self._ws.send_json({"type": "offer", "sdp": encoded_sdp})
+            await self._ws.send_json({"type": "offer", "sdp": encode(offer_sdp)})
 
             if self._pending_candidates:
                 _LOGGER.debug(
@@ -381,6 +450,7 @@ class CameraSignalingRelay:
                 self._receive_loop(on_answer, on_candidate)
             )
             self._ping_task = asyncio.ensure_future(self._ping_loop())
+            self._started = True
         except Exception:
             if self._ws is not None and not self._ws.closed:
                 await self._ws.close()
@@ -420,9 +490,14 @@ class CameraSignalingRelay:
         _LOGGER.debug(
             "Signaling relay: WS closed -- buffering ICE candidate for reconnect"
         )
+        if len(self._pending_candidates) >= MAX_PENDING_CANDIDATES:
+            _LOGGER.warning("Signaling relay: candidate buffer full -- dropping oldest")
+            self._pending_candidates.pop(0)
         self._pending_candidates.append(msg)
+        # Only reconnect once start() has completed; before that, start()'s own
+        # flush delivers the buffer (a parallel socket here would race the offer).
         if (
-            self._session
+            self._started
             and not self._closed
             and (self._reconnect_task is None or self._reconnect_task.done())
         ):
@@ -432,15 +507,7 @@ class CameraSignalingRelay:
         """Cancel tasks and close the signaling WebSocket."""
         self._closed = True
 
-        for task in filter(
-            None, [self._ping_task, self._receive_task, self._reconnect_task]
-        ):
-            if not task.done():
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+        await cancel_task(self._ping_task, self._receive_task, self._reconnect_task)
 
         if self._ws and not self._ws.closed:
             await self._ws.close()
@@ -456,49 +523,26 @@ class CameraSignalingRelay:
             async for msg in self._ws:  # type: ignore[union-attr]
                 if self._closed:
                     break
-                _LOGGER.debug("Signaling relay: received msg type=%s", msg.type)
-                if msg.type == WSMsgType.TEXT:
-                    data = msg.json()
-                    msg_type = data.get("type", "")
-                    _LOGGER.debug(
-                        "Signaling relay: message type=%s keys=%s",
-                        msg_type,
-                        list(data.keys()),
-                    )
-
-                    if msg_type == "answer":
-                        raw_sdp = data.get("payload") or data.get("sdp", "")
-                        try:
-                            decoded = b64decode(raw_sdp).decode()
-                            sdp = (
-                                decoded if decoded.strip().startswith("v=") else raw_sdp
-                            )
-                        except Exception:
-                            _LOGGER.debug(
-                                "Signaling relay: SDP not base64-encoded, using raw"
-                            )
-                            sdp = raw_sdp
-                        _LOGGER.debug(
-                            "Signaling relay: received answer (%d bytes)",
-                            len(sdp),
-                        )
-                        on_answer(sdp)
-
-                    elif msg_type == "candidate" or "candidate" in data:
-                        candidate_str = data.get("candidate", "")
-                        if candidate_str:
-                            _LOGGER.debug("Signaling relay: received ICE candidate")
-                            on_candidate(
-                                {
-                                    "candidate": candidate_str,
-                                    "sdpMid": data.get("sdpMid", "0"),
-                                    "sdpMLineIndex": data.get("sdpMLineIndex", 0),
-                                }
-                            )
-
-                elif msg.type in (WSMsgType.CLOSED, WSMsgType.ERROR):
+                if msg.type in (WSMsgType.CLOSED, WSMsgType.ERROR):
                     _LOGGER.debug("Signaling relay: WS closed/error type=%s", msg.type)
                     break
+                if msg.type != WSMsgType.TEXT:
+                    continue
+                # isolate per-message errors so one bad frame can't end signaling
+                try:
+                    data = msg.json()
+                    if not isinstance(data, dict):
+                        continue
+                    if (parsed := _parse_signaling_message(data)) is None:
+                        continue
+                    kind, payload = parsed
+                    _LOGGER.debug("Signaling relay: received %s", kind)
+                    if kind == "answer":
+                        on_answer(payload)
+                    else:
+                        on_candidate(payload)
+                except Exception:
+                    _LOGGER.exception("Signaling relay: error handling message")
             _LOGGER.debug("Signaling relay: receive loop ended")
         except asyncio.CancelledError:
             raise
@@ -524,11 +568,9 @@ class CameraSignalingRelay:
             )
             try:
                 websession = self._client.websession
-                ws_url = (
-                    f"{self._session.signaling_url}"
-                    f"?accessToken={self._session.session_token}"
+                ws = await websession.ws_connect(
+                    self._session.ws_url, headers=_WS_HEADERS
                 )
-                ws = await websession.ws_connect(ws_url)
                 pending, self._pending_candidates = self._pending_candidates, []
                 sent = 0
                 try:
@@ -546,24 +588,12 @@ class CameraSignalingRelay:
                     await ws.close()
             except Exception:
                 if not self._closed:
-                    _LOGGER.debug(
-                        "Signaling relay: late ICE candidate reconnect failed",
+                    _LOGGER.warning(
+                        "Signaling relay: failed to forward %d late ICE candidate(s)",
+                        len(self._pending_candidates),
                         exc_info=True,
                     )
                 break
-
-    async def _ping_loop(self) -> None:
-        """Send periodic pings to keep the signaling connection alive."""
-        try:
-            while not self._closed:
-                await asyncio.sleep(PING_INTERVAL)
-                if self._ws and not self._ws.closed:
-                    await self._ws.ping()
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            if not self._closed:
-                _LOGGER.debug("Relay ping loop ended")
 
 
 try:
@@ -580,7 +610,7 @@ except ImportError:
     HAS_AIORTC = False
 
 
-class CameraStream:
+class CameraStream(_SignalingMixin):
     """WebRTC live stream for an LR5 Pro camera.
 
     Requires the ``aiortc`` package.  Install with::
@@ -627,6 +657,10 @@ class CameraStream:
         self._connected = asyncio.Event()
         self._stopped = False
 
+    @property
+    def _finished(self) -> bool:
+        return self._stopped
+
     def on_video_frame(self, callback: Callable) -> None:
         """Register a callback for incoming video frames."""
         self._video_callback = callback
@@ -640,7 +674,13 @@ class CameraStream:
         self._state_callback = callback
 
     async def start(self) -> None:
-        """Start the WebRTC streaming session."""
+        """Start the WebRTC streaming session.
+
+        Raises:
+            CameraStreamException: If the stream is stopped/started or the
+                camera session could not be generated.
+
+        """
         if self._stopped:
             raise CameraStreamException("Stream has been stopped")
         if self._pc is not None:
@@ -681,22 +721,18 @@ class CameraStream:
 
         try:
             websession = self._client.websession
-            ws_url = (
-                f"{self._session.signaling_url}"
-                f"?accessToken={self._session.session_token}"
+            self._ws = await websession.ws_connect(
+                self._session.ws_url, headers=_WS_HEADERS
             )
-            self._ws = await websession.ws_connect(ws_url)
 
             # localDescription.sdp includes gathered ICE candidates; offer.sdp has none
             offer = await self._pc.createOffer()
             await self._pc.setLocalDescription(offer)
 
-            local_sdp = self._pc.localDescription.sdp
-            encoded_sdp = b64encode(local_sdp.encode()).decode()
             await self._ws.send_json(
                 {
                     "type": "offer",
-                    "sdp": encoded_sdp,
+                    "sdp": encode(self._pc.localDescription.sdp),
                 }
             )
         except Exception:
@@ -715,30 +751,8 @@ class CameraStream:
         """Stop the WebRTC streaming session and clean up resources."""
         self._stopped = True
 
-        for task in self._media_tasks:
-            if not task.done():
-                task.cancel()
-        for task in self._media_tasks:
-            if not task.done():
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+        await cancel_task(*self._media_tasks, self._ping_task, self._receive_task)
         self._media_tasks.clear()
-
-        if self._ping_task and not self._ping_task.done():
-            self._ping_task.cancel()
-            try:
-                await self._ping_task
-            except asyncio.CancelledError:
-                pass
-
-        if self._receive_task and not self._receive_task.done():
-            self._receive_task.cancel()
-            try:
-                await self._receive_task
-            except asyncio.CancelledError:
-                pass
 
         if self._ws and not self._ws.closed:
             await self._ws.close()
@@ -775,12 +789,15 @@ class CameraStream:
     def _build_ice_servers(
         turn_creds: list[dict[str, Any]],
     ) -> list[RTCIceServer]:
-        """Convert TURN credentials to RTCIceServer objects."""
-        servers: list[RTCIceServer] = [
-            RTCIceServer(urls="stun:stun.l.google.com:19302"),
-        ]
+        """Convert TURN credentials to RTCIceServer objects.
+
+        Prefers the vendor-provided STUN server from the session response;
+        falls back to a public STUN server only if none is provided.
+        """
+        servers: list[RTCIceServer] = []
+        has_stun = False
         for cred in turn_creds:
-            urls = cred.get("turnUrl") or cred.get("urls") or cred.get("uris") or []
+            urls = first_value(cred, ("turnUrl", "urls", "uris")) or []
             if isinstance(urls, str):
                 urls = [urls]
             if urls:
@@ -788,7 +805,9 @@ class CameraStream:
                     RTCIceServer(
                         urls=urls,
                         username=cred.get("username", ""),
-                        credential=cred.get("password") or cred.get("credential", ""),
+                        credential=first_value(
+                            cred, ("password", "credential"), default=""
+                        ),
                     )
                 )
             stun_url = cred.get("stunUrl")
@@ -797,6 +816,9 @@ class CameraStream:
                 for s in servers
             ):
                 servers.append(RTCIceServer(urls=stun_url))
+                has_stun = True
+        if not has_stun:
+            servers.append(RTCIceServer(urls=FALLBACK_STUN_URL))
         return servers
 
     async def _consume_track(self, track: Any, callback: Callable) -> None:
@@ -818,10 +840,18 @@ class CameraStream:
             async for msg in self._ws:  # type: ignore[union-attr]
                 if self._stopped:
                     break
-                if msg.type == WSMsgType.TEXT:
-                    await self._handle_signaling_message(msg.json())
-                elif msg.type in (WSMsgType.CLOSED, WSMsgType.ERROR):
+                if msg.type in (WSMsgType.CLOSED, WSMsgType.ERROR):
                     break
+                if msg.type != WSMsgType.TEXT:
+                    continue
+                # isolate per-message errors so one bad frame can't end signaling
+                try:
+                    data = msg.json()
+                    if isinstance(data, dict):
+                        await self._handle_signaling_message(data)
+                except Exception:
+                    if not self._stopped:
+                        _LOGGER.exception("Error handling signaling message")
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -830,48 +860,23 @@ class CameraStream:
 
     async def _handle_signaling_message(self, data: dict[str, Any]) -> None:
         """Handle an incoming signaling message (answer or ICE candidate)."""
-        msg_type = data.get("type", "")
+        if (parsed := _parse_signaling_message(data)) is None:
+            return
+        kind, payload = parsed
 
-        if msg_type == "answer":
-            raw_sdp = data.get("payload") or data.get("sdp", "")
-            try:
-                decoded = b64decode(raw_sdp).decode()
-                sdp = decoded if decoded.strip().startswith("v=") else raw_sdp
-            except Exception:
-                _LOGGER.debug("CameraStream: SDP not base64-encoded, using raw")
-                sdp = raw_sdp
-
-            answer = RTCSessionDescription(sdp=sdp, type="answer")
+        if kind == "answer":
+            answer = RTCSessionDescription(sdp=payload, type="answer")
             await self._pc.setRemoteDescription(answer)  # type: ignore[union-attr]
             _LOGGER.debug("Set remote description (answer)")
+            return
 
-        elif msg_type == "candidate" or "candidate" in data:
-            candidate_str = data.get("candidate", "")
-            if not candidate_str:
-                return
-            sdp_mid = data.get("sdpMid", "0")
-            sdp_mline_index = data.get("sdpMLineIndex", 0)
-
-            try:
-                candidate = candidate_from_sdp(candidate_str)
-                candidate.sdpMid = sdp_mid
-                candidate.sdpMLineIndex = sdp_mline_index
-            except Exception:
-                _LOGGER.warning("Failed to parse ICE candidate: %s", candidate_str[:80])
-                return
-
-            await self._pc.addIceCandidate(candidate)  # type: ignore[union-attr]
-            _LOGGER.debug("Added ICE candidate: %s", candidate_str[:60])
-
-    async def _ping_loop(self) -> None:
-        """Send periodic pings to keep the signaling connection alive."""
+        candidate_str = payload["candidate"]
         try:
-            while not self._stopped:
-                await asyncio.sleep(PING_INTERVAL)
-                if self._ws and not self._ws.closed:
-                    await self._ws.ping()
-        except asyncio.CancelledError:
-            raise
+            candidate = candidate_from_sdp(candidate_str)
+            candidate.sdpMid = payload["sdpMid"]
+            candidate.sdpMLineIndex = payload["sdpMLineIndex"]
+            await self._pc.addIceCandidate(candidate)  # type: ignore[union-attr]
         except Exception:
-            if not self._stopped:
-                _LOGGER.debug("Ping loop ended")
+            _LOGGER.warning("Failed to add ICE candidate: %s", candidate_str[:80])
+            return
+        _LOGGER.debug("Added ICE candidate: %s", candidate_str[:60])

--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -20,14 +20,14 @@ from typing import TYPE_CHECKING, Any, Callable
 from aiohttp import ClientResponseError, ClientSession, WSMsgType
 
 from .exceptions import CameraStreamException
-from .utils import to_timestamp
+from .utils import to_timestamp, utcnow
 
 if TYPE_CHECKING:
     from .session import Session
 
 _LOGGER = logging.getLogger(__name__)
 
-WATFORD_API = "https://watford.ienso-dev.com"
+WATFORD_API = "https://watford.ienso-dev.com"  # vendor-maintained URL; the -dev suffix is intentional
 CAMERA_SETTINGS_API = "https://7mnuil943l.execute-api.us-east-1.amazonaws.com"
 CAMERA_INVENTORY_API = "https://rrntg65uwf.execute-api.us-east-1.amazonaws.com"
 
@@ -174,7 +174,8 @@ class CameraClient:
         url = f"{self._settings_base}/reported-settings/{settings_type}"
         try:
             data = await self._session.get(url, headers=self._settings_headers())
-        except ClientResponseError:
+        except ClientResponseError as err:
+            _LOGGER.debug("get_video_settings failed: %s", err)
             return None
         return data if isinstance(data, dict) else None
 
@@ -185,8 +186,6 @@ class CameraClient:
             canvas: One of ``CAMERA_CANVAS_FRONT`` or ``CAMERA_CANVAS_GLOBE``.
 
         """
-        from .utils import utcnow
-
         url = f"{self._settings_base}/desired-settings/videoSettings"
         payload = {
             "streams": {"live-view": {"canvas": canvas}},
@@ -197,7 +196,8 @@ class CameraClient:
                 url, json=payload, headers=self._settings_headers()
             )
             return True
-        except ClientResponseError:
+        except ClientResponseError as err:
+            _LOGGER.debug("set_camera_canvas failed: %s", err)
             return False
 
     async def set_audio_enabled(self, enabled: bool) -> bool:
@@ -216,7 +216,8 @@ class CameraClient:
                 url, json=payload, headers=self._settings_headers()
             )
             return True
-        except ClientResponseError:
+        except ClientResponseError as err:
+            _LOGGER.debug("set_audio_enabled failed: %s", err)
             return False
 
     async def get_audio_settings(self) -> dict[str, Any] | None:
@@ -224,7 +225,8 @@ class CameraClient:
         url = f"{self._settings_base}/reported-settings/audioSettings"
         try:
             data = await self._session.get(url, headers=self._settings_headers())
-        except ClientResponseError:
+        except ClientResponseError as err:
+            _LOGGER.debug("get_audio_settings failed: %s", err)
             return None
         return data if isinstance(data, dict) else None
 
@@ -233,7 +235,8 @@ class CameraClient:
         url = self._inventory_base
         try:
             data = await self._session.get(url, headers=self._settings_headers())
-        except ClientResponseError:
+        except ClientResponseError as err:
+            _LOGGER.debug("get_camera_info failed: %s", err)
             return None
         return data if isinstance(data, dict) else None
 
@@ -260,7 +263,8 @@ class CameraClient:
                 headers=self._settings_headers(),
                 params=params or None,
             )
-        except ClientResponseError:
+        except ClientResponseError as err:
+            _LOGGER.debug("get_videos failed: %s", err)
             return []
         if not isinstance(data, list):
             return []
@@ -286,7 +290,8 @@ class CameraClient:
                 headers=self._settings_headers(),
                 params=params or None,
             )
-        except ClientResponseError:
+        except ClientResponseError as err:
+            _LOGGER.debug("get_events failed: %s", err)
             return []
         if not isinstance(data, list):
             return []
@@ -456,6 +461,9 @@ class CameraSignalingRelay:
                         try:
                             sdp = b64decode(raw_sdp).decode()
                         except Exception:
+                            _LOGGER.debug(
+                                "Signaling relay: SDP not base64-encoded, using raw"
+                            )
                             sdp = raw_sdp
                         _LOGGER.debug(
                             "Signaling relay: received answer (%d bytes)",
@@ -574,12 +582,11 @@ class CameraStream:
             # ... frames delivered via callback ...
     """
 
-    def __init__(self, client: CameraClient, **kwargs: Any) -> None:
+    def __init__(self, client: CameraClient) -> None:
         """Initialize the camera stream.
 
         Args:
             client: A ``CameraClient`` instance.
-            **kwargs: Extra keyword arguments (reserved for future use).
 
         Raises:
             ImportError: If ``aiortc`` is not installed.
@@ -592,7 +599,6 @@ class CameraStream:
             )
 
         self._client = client
-        self._kwargs = kwargs
 
         self._session: CameraSession | None = None
         self._pc: RTCPeerConnection | None = None
@@ -757,7 +763,7 @@ class CameraStream:
     @staticmethod
     def _build_ice_servers(
         turn_creds: list[dict[str, Any]],
-    ) -> list[Any]:
+    ) -> list[RTCIceServer]:
         """Convert TURN credentials to RTCIceServer objects."""
         servers: list[RTCIceServer] = [
             RTCIceServer(urls="stun:stun.l.google.com:19302"),
@@ -820,6 +826,7 @@ class CameraStream:
             try:
                 sdp = b64decode(raw_sdp).decode()
             except Exception:
+                _LOGGER.debug("CameraStream: SDP not base64-encoded, using raw")
                 sdp = raw_sdp
 
             answer = RTCSessionDescription(sdp=sdp, type="answer")

--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -354,29 +354,34 @@ class CameraSignalingRelay:
 
         self._session = await self._client.generate_session()
 
-        websession = self._client.websession
-        ws_url = (
-            f"{self._session.signaling_url}?accessToken={self._session.session_token}"
-        )
-        self._ws = await websession.ws_connect(ws_url)
+        try:
+            websession = self._client.websession
+            ws_url = f"{self._session.signaling_url}?accessToken={self._session.session_token}"
+            self._ws = await websession.ws_connect(ws_url)
 
-        encoded_sdp = b64encode(offer_sdp.encode()).decode()
-        _LOGGER.debug("Signaling relay: sending offer (%d bytes)", len(offer_sdp))
-        await self._ws.send_json({"type": "offer", "sdp": encoded_sdp})
+            encoded_sdp = b64encode(offer_sdp.encode()).decode()
+            _LOGGER.debug("Signaling relay: sending offer (%d bytes)", len(offer_sdp))
+            await self._ws.send_json({"type": "offer", "sdp": encoded_sdp})
 
-        if self._pending_candidates:
-            _LOGGER.debug(
-                "Signaling relay: flushing %d buffered ICE candidates",
-                len(self._pending_candidates),
+            if self._pending_candidates:
+                _LOGGER.debug(
+                    "Signaling relay: flushing %d buffered ICE candidates",
+                    len(self._pending_candidates),
+                )
+                for msg in self._pending_candidates:
+                    await self._ws.send_json(msg)
+                self._pending_candidates.clear()
+
+            self._receive_task = asyncio.ensure_future(
+                self._receive_loop(on_answer, on_candidate)
             )
-            for msg in self._pending_candidates:
-                await self._ws.send_json(msg)
-            self._pending_candidates.clear()
-
-        self._receive_task = asyncio.ensure_future(
-            self._receive_loop(on_answer, on_candidate)
-        )
-        self._ping_task = asyncio.ensure_future(self._ping_loop())
+            self._ping_task = asyncio.ensure_future(self._ping_loop())
+        except Exception:
+            if self._ws is not None and not self._ws.closed:
+                await self._ws.close()
+            self._ws = None
+            self._session = None
+            raise
 
         return self._session
 
@@ -459,7 +464,10 @@ class CameraSignalingRelay:
                     if msg_type == "answer":
                         raw_sdp = data.get("payload") or data.get("sdp", "")
                         try:
-                            sdp = b64decode(raw_sdp).decode()
+                            decoded = b64decode(raw_sdp).decode()
+                            sdp = (
+                                decoded if decoded.strip().startswith("v=") else raw_sdp
+                            )
                         except Exception:
                             _LOGGER.debug(
                                 "Signaling relay: SDP not base64-encoded, using raw"
@@ -824,7 +832,8 @@ class CameraStream:
         if msg_type == "answer":
             raw_sdp = data.get("payload") or data.get("sdp", "")
             try:
-                sdp = b64decode(raw_sdp).decode()
+                decoded = b64decode(raw_sdp).decode()
+                sdp = decoded if decoded.strip().startswith("v=") else raw_sdp
             except Exception:
                 _LOGGER.debug("CameraStream: SDP not base64-encoded, using raw")
                 sdp = raw_sdp

--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -66,18 +66,39 @@ def _decode_sdp(raw_sdp: str) -> str:
     return raw_sdp
 
 
+def _is_complete_sdp(sdp: str) -> bool:
+    r"""Check that an SDP answer has a version line and at least one media section.
+
+    The camera occasionally emits a truncated answer (observed live: just
+    ``"v=0\r\n"``), which hard-fails the peer's SDP parser if forwarded.
+    """
+    return sdp.startswith("v=") and any(
+        line.startswith("m=") for line in sdp.splitlines()
+    )
+
+
 def _parse_signaling_message(data: dict[str, Any]) -> tuple[str, Any] | None:
     """Parse a signaling message into ``("answer", sdp)`` or ``("candidate", dict)``.
 
-    Returns ``None`` for messages that carry neither. Explicit JSON ``null``
-    values for ``sdpMid``/``sdpMLineIndex`` are normalized to their defaults
+    Returns ``None`` for messages that carry neither, and for truncated
+    answer SDPs (the peer would reject them; the camera may still send a
+    complete answer afterwards). Explicit JSON ``null`` values for
+    ``sdpMid``/``sdpMLineIndex`` are normalized to their defaults
     (``dict.get`` defaults do not apply to present-but-null keys).
     """
     msg_type = data.get("type", "")
 
     if msg_type == "answer":
         raw_sdp = data.get("payload") or data.get("sdp", "")
-        return ("answer", _decode_sdp(raw_sdp))
+        sdp = _decode_sdp(raw_sdp)
+        if not _is_complete_sdp(sdp):
+            _LOGGER.warning(
+                "Signaling: discarding malformed answer SDP (%d bytes): %r",
+                len(sdp),
+                sdp[:80],
+            )
+            return None
+        return ("answer", sdp)
 
     if msg_type == "candidate" or "candidate" in data:
         if not (candidate := data.get("candidate", "")):

--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -17,7 +17,12 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Callable
 
-from aiohttp import ClientResponseError, ClientSession, WSMsgType
+from aiohttp import (
+    ClientResponseError,
+    ClientSession,
+    ClientWebSocketResponse,
+    WSMsgType,
+)
 
 from .exceptions import CameraStreamException
 from .utils import to_timestamp, utcnow
@@ -318,7 +323,7 @@ class CameraSignalingRelay:
         """
         self._client = client
         self._session: CameraSession | None = None
-        self._ws: Any | None = None  # aiohttp ClientWebSocketResponse
+        self._ws: ClientWebSocketResponse | None = None
         self._ping_task: asyncio.Task[None] | None = None
         self._receive_task: asyncio.Task[None] | None = None
         self._closed = False
@@ -610,7 +615,7 @@ class CameraStream:
 
         self._session: CameraSession | None = None
         self._pc: RTCPeerConnection | None = None
-        self._ws: Any | None = None  # aiohttp ClientWebSocketResponse
+        self._ws: ClientWebSocketResponse | None = None
         self._ping_task: asyncio.Task[None] | None = None
         self._receive_task: asyncio.Task[None] | None = None
         self._media_tasks: list[asyncio.Task[None]] = []
@@ -682,9 +687,7 @@ class CameraStream:
             )
             self._ws = await websession.ws_connect(ws_url)
 
-            # setLocalDescription gathers ICE candidates internally.
-            # We must send localDescription.sdp (which includes all gathered
-            # candidates) rather than offer.sdp (which has none).
+            # localDescription.sdp includes gathered ICE candidates; offer.sdp has none
             offer = await self._pc.createOffer()
             await self._pc.setLocalDescription(offer)
 

--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -290,7 +290,8 @@ class CameraClient:
             return []
         if not isinstance(data, list):
             return []
-        return [item for item in data if isinstance(item, dict)]
+        events = [item for item in data if isinstance(item, dict)]
+        return events[:limit] if limit is not None else events
 
 
 class CameraSignalingRelay:
@@ -343,6 +344,8 @@ class CameraSignalingRelay:
         """
         if self._closed:
             raise CameraStreamException("Relay has been closed")
+        if self._session is not None:
+            raise CameraStreamException("Relay already started")
 
         self._session = await self._client.generate_session()
 
@@ -773,7 +776,8 @@ class CameraStream:
                 )
             stun_url = cred.get("stunUrl")
             if stun_url and not any(
-                stun_url == s.urls or stun_url in s.urls for s in servers
+                stun_url == s.urls or (isinstance(s.urls, list) and stun_url in s.urls)
+                for s in servers
             ):
                 servers.append(RTCIceServer(urls=stun_url))
         return servers

--- a/pylitterbot/const.py
+++ b/pylitterbot/const.py
@@ -1,0 +1,4 @@
+"""Constants."""
+
+API_V2_ENDPOINT = "https://v2.api.whisker.iothings.site"
+API_V2_ENDPOINT_KEY = "cDduZE1vajYxbnBSWlA1Q1Z6OXY0VWowYkc3Njl4eTY3NThRUkJQYg=="

--- a/pylitterbot/exceptions.py
+++ b/pylitterbot/exceptions.py
@@ -11,3 +11,15 @@ class LitterRobotLoginException(LitterRobotException):
 
 class InvalidCommandException(LitterRobotException):
     """To be thrown in the event an invalid command is sent."""
+
+
+class CameraNotAvailableException(LitterRobotException):
+    """Raised when a camera operation is attempted on a robot without a camera."""
+
+
+class CameraStreamException(LitterRobotException):
+    """Raised when a camera streaming operation fails."""
+
+
+class CameraSessionExpiredException(CameraStreamException):
+    """Raised when the camera session token has expired."""

--- a/pylitterbot/exceptions.py
+++ b/pylitterbot/exceptions.py
@@ -19,7 +19,3 @@ class CameraNotAvailableException(LitterRobotException):
 
 class CameraStreamException(LitterRobotException):
     """Raised when a camera streaming operation fails."""
-
-
-class CameraSessionExpiredException(CameraStreamException):
-    """Raised when the camera session token has expired."""

--- a/pylitterbot/robot/litterrobot3.py
+++ b/pylitterbot/robot/litterrobot3.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 import aiohttp
 
 from ..activity import Activity, Insight
+from ..const import API_V2_ENDPOINT
 from ..enums import LitterBoxCommand, LitterBoxStatus
 from ..exceptions import InvalidCommandException
 from ..sleep_schedule import SleepSchedule
@@ -21,8 +22,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_ENDPOINT = "https://v2.api.whisker.iothings.site"
-DEFAULT_ENDPOINT_KEY = "cDduZE1vajYxbnBSWlA1Q1Z6OXY0VWowYkc3Njl4eTY3NThRUkJQYg=="
+DEFAULT_ENDPOINT = API_V2_ENDPOINT
 WEBSOCKET_ENDPOINT = "https://8s1fz54a82.execute-api.us-east-1.amazonaws.com/prod"
 
 SLEEP_MODE_ACTIVE = "sleepModeActive"

--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -19,7 +19,11 @@ from ..enums import (
     LitterRobot5Command,
     NightLightMode,
 )
-from ..exceptions import InvalidCommandException, LitterRobotException
+from ..exceptions import (
+    CameraNotAvailableException,
+    InvalidCommandException,
+    LitterRobotException,
+)
 from ..sleep_schedule import SleepSchedule
 from ..transport import PollingTransport
 from ..utils import calculate_litter_level, to_enum, to_timestamp, urljoin
@@ -27,6 +31,7 @@ from .litterrobot import LitterRobot
 
 if TYPE_CHECKING:
     from ..account import Account
+    from ..camera import CameraClient, CameraSession, CameraStream, VideoClip
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -130,6 +135,7 @@ class LitterRobot5(LitterRobot):
         """Initialize a Litter-Robot 5."""
         super().__init__(data, account)
         self._path = LR5_ENDPOINT
+        self._camera_audio_enabled: bool | None = None
 
     @property
     def is_pro(self) -> bool:
@@ -482,7 +488,14 @@ class LitterRobot5(LitterRobot):
 
     @property
     def camera_audio_enabled(self) -> bool:
-        """Return `True` if camera audio is enabled (Pro only)."""
+        """Return `True` if camera audio is enabled (Pro only).
+
+        Uses locally cached state from ``set_camera_audio`` when available,
+        since the robot API's ``soundSettings.cameraAudioEnabled`` field does
+        not reflect changes made via the camera settings API.
+        """
+        if self._camera_audio_enabled is not None:
+            return self._camera_audio_enabled
         return self._sound_settings.get("cameraAudioEnabled") is True
 
     @property
@@ -830,10 +843,13 @@ class LitterRobot5(LitterRobot):
 
     async def set_camera_audio(self, value: bool) -> bool:
         """Enable or disable camera audio (Pro only)."""
-        return await self._dispatch_command(
-            LitterRobot5Command.SOUND_SETTINGS,
-            value={"cameraAudioEnabled": value},
-        )
+        if not self.has_camera:
+            return False
+        client = self.get_camera_client()
+        if await client.set_audio_enabled(value):
+            self._camera_audio_enabled = value
+            return True
+        return False
 
     async def set_wait_time(self, wait_time: int) -> bool:
         """Set the wait time on the Litter-Robot."""
@@ -1005,6 +1021,107 @@ class LitterRobot5(LitterRobot):
         ) as ex:
             _LOGGER.error("Reassign pet visit failed: %s", ex)
             return None
+
+    @property
+    def has_camera(self) -> bool:
+        """Return `True` if this robot has camera metadata (Pro model)."""
+        cam = self.camera_metadata
+        return isinstance(cam, dict) and bool(cam.get("deviceId"))
+
+    def get_camera_client(self) -> CameraClient:
+        """Return a ``CameraClient`` for this robot's camera.
+
+        Raises:
+            CameraNotAvailableException: If the robot has no camera.
+
+        """
+        from ..camera import CameraClient
+        from ..utils import decode
+
+        cam = self.camera_metadata
+        if not cam or not cam.get("deviceId"):
+            raise CameraNotAvailableException(
+                f"Robot {self.serial} does not have a camera"
+            )
+
+        from .litterrobot3 import DEFAULT_ENDPOINT_KEY
+
+        return CameraClient(
+            session=self._account.session,
+            device_id=cam["deviceId"],
+            api_key=decode(DEFAULT_ENDPOINT_KEY),
+        )
+
+    async def get_camera_session(self) -> CameraSession:
+        """Generate a camera streaming session.
+
+        Returns:
+            A ``CameraSession`` with TURN credentials and signaling URL.
+
+        Raises:
+            CameraNotAvailableException: If the robot has no camera.
+
+        """
+        client = self.get_camera_client()
+        return await client.generate_session()
+
+    async def get_camera_videos(
+        self, *, date: str | None = None, limit: int | None = None
+    ) -> list[VideoClip]:
+        """Fetch recorded camera video clips.
+
+        Args:
+            date: Optional date (YYYY-MM-DD) filter.
+            limit: Optional max results.
+
+        """
+        client = self.get_camera_client()
+        return list(await client.get_videos(date=date, limit=limit))
+
+    async def get_camera_video_settings(self) -> dict[str, Any] | None:
+        """Fetch the camera's reported video settings."""
+        client = self.get_camera_client()
+        return await client.get_video_settings()
+
+    async def set_camera_view(self, view: str) -> bool:
+        """Switch the camera live-view canvas.
+
+        Args:
+            view: ``"front"`` or ``"globe"``.
+
+        Raises:
+            InvalidCommandException: If the view is not recognized.
+            CameraNotAvailableException: If the robot has no camera.
+
+        """
+        from ..camera import CAMERA_CANVAS_FRONT, CAMERA_CANVAS_GLOBE
+
+        view_map = {
+            "front": CAMERA_CANVAS_FRONT,
+            "globe": CAMERA_CANVAS_GLOBE,
+        }
+        canvas = view_map.get(view.lower())
+        if canvas is None:
+            raise InvalidCommandException(
+                f"Invalid camera view {view!r}. Must be 'front' or 'globe'."
+            )
+        client = self.get_camera_client()
+        return await client.set_camera_canvas(canvas)
+
+    def create_camera_stream(self, **kwargs: Any) -> CameraStream:
+        """Create a ``CameraStream`` for live WebRTC streaming.
+
+        Requires the ``aiortc`` optional dependency.
+
+        Raises:
+            CameraNotAvailableException: If the robot has no camera.
+            ImportError: If ``aiortc`` is not installed.
+
+        """
+        from ..camera import CameraStream
+
+        client = self.get_camera_client()
+        return CameraStream(client, **kwargs)
 
     @classmethod
     async def fetch_for_account(cls, account: Account) -> list[dict[str, object]]:

--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -16,6 +16,7 @@ from ..camera import (
     CameraClient,
     CameraStream,
 )
+from ..const import API_V2_ENDPOINT_KEY
 from ..enums import (
     BrightnessLevel,
     GlobeMotorFaultStatus,
@@ -34,7 +35,6 @@ from ..sleep_schedule import SleepSchedule
 from ..transport import PollingTransport
 from ..utils import calculate_litter_level, decode, to_enum, to_timestamp, urljoin
 from .litterrobot import LitterRobot
-from .litterrobot3 import DEFAULT_ENDPOINT_KEY
 
 if TYPE_CHECKING:
     from ..account import Account
@@ -1085,7 +1085,7 @@ class LitterRobot5(LitterRobot):
             self._camera_client = CameraClient(
                 session=self._account.session,
                 device_id=cam["deviceId"],
-                api_key=decode(DEFAULT_ENDPOINT_KEY),
+                api_key=decode(API_V2_ENDPOINT_KEY),
             )
         return self._camera_client
 

--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -10,6 +10,12 @@ from typing import TYPE_CHECKING, Any, cast
 from aiohttp import ClientConnectionError, ClientConnectorError, ClientResponseError
 
 from ..activity import Activity, Insight
+from ..camera import (
+    CAMERA_CANVAS_FRONT,
+    CAMERA_CANVAS_GLOBE,
+    CameraClient,
+    CameraStream,
+)
 from ..enums import (
     BrightnessLevel,
     GlobeMotorFaultStatus,
@@ -26,12 +32,13 @@ from ..exceptions import (
 )
 from ..sleep_schedule import SleepSchedule
 from ..transport import PollingTransport
-from ..utils import calculate_litter_level, to_enum, to_timestamp, urljoin
+from ..utils import calculate_litter_level, decode, to_enum, to_timestamp, urljoin
 from .litterrobot import LitterRobot
+from .litterrobot3 import DEFAULT_ENDPOINT_KEY
 
 if TYPE_CHECKING:
     from ..account import Account
-    from ..camera import CameraClient, CameraSession, CameraStream, VideoClip
+    from ..camera import CameraSession, VideoClip
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -136,6 +143,7 @@ class LitterRobot5(LitterRobot):
         super().__init__(data, account)
         self._path = LR5_ENDPOINT
         self._camera_audio_enabled: bool | None = None
+        self._camera_client: CameraClient | None = None
 
     @property
     def is_pro(self) -> bool:
@@ -492,7 +500,9 @@ class LitterRobot5(LitterRobot):
 
         Uses locally cached state from ``set_camera_audio`` when available,
         since the robot API's ``soundSettings.cameraAudioEnabled`` field does
-        not reflect changes made via the camera settings API.
+        not reflect changes made via the camera settings API.  Call
+        ``refresh_camera_audio_enabled`` to reconcile the cache with the
+        camera's reported settings (e.g. after changes in the Whisker app).
         """
         if self._camera_audio_enabled is not None:
             return self._camera_audio_enabled
@@ -842,14 +852,44 @@ class LitterRobot5(LitterRobot):
         )
 
     async def set_camera_audio(self, value: bool) -> bool:
-        """Enable or disable camera audio (Pro only)."""
-        if not self.has_camera:
-            return False
+        """Enable or disable camera audio (Pro only).
+
+        Raises:
+            CameraNotAvailableException: If the robot has no camera.
+
+        """
         client = self.get_camera_client()
         if await client.set_audio_enabled(value):
             self._camera_audio_enabled = value
             return True
         return False
+
+    async def refresh_camera_audio_enabled(self) -> bool | None:
+        """Fetch the camera microphone state from the camera settings API.
+
+        Reconciles the locally cached value used by ``camera_audio_enabled``
+        with the camera's reported settings, so changes made outside this
+        client (e.g. in the Whisker app) are picked up.
+
+        Returns:
+            The current state, or ``None`` if it could not be determined.
+
+        Raises:
+            CameraNotAvailableException: If the robot has no camera.
+
+        """
+        client = self.get_camera_client()
+        if (settings := await client.get_audio_settings()) is None:
+            return None
+        mute = None
+        if isinstance(audio_in := settings.get("audio_in"), dict) and isinstance(
+            audio_global := audio_in.get("global"), dict
+        ):
+            mute = audio_global.get("mute")
+        if not isinstance(mute, bool):
+            return None
+        self._camera_audio_enabled = not mute
+        return self._camera_audio_enabled
 
     async def set_wait_time(self, wait_time: int) -> bool:
         """Set the wait time on the Litter-Robot."""
@@ -1035,22 +1075,19 @@ class LitterRobot5(LitterRobot):
             CameraNotAvailableException: If the robot has no camera.
 
         """
-        from ..camera import CameraClient
-        from ..utils import decode
-
         cam = self.camera_metadata
         if not cam or not cam.get("deviceId"):
             raise CameraNotAvailableException(
                 f"Robot {self.serial} does not have a camera"
             )
 
-        from .litterrobot3 import DEFAULT_ENDPOINT_KEY
-
-        return CameraClient(
-            session=self._account.session,
-            device_id=cam["deviceId"],
-            api_key=decode(DEFAULT_ENDPOINT_KEY),
-        )
+        if self._camera_client is None:
+            self._camera_client = CameraClient(
+                session=self._account.session,
+                device_id=cam["deviceId"],
+                api_key=decode(DEFAULT_ENDPOINT_KEY),
+            )
+        return self._camera_client
 
     async def get_camera_session(self) -> CameraSession:
         """Generate a camera streaming session.
@@ -1094,8 +1131,6 @@ class LitterRobot5(LitterRobot):
             CameraNotAvailableException: If the robot has no camera.
 
         """
-        from ..camera import CAMERA_CANVAS_FRONT, CAMERA_CANVAS_GLOBE
-
         view_map = {
             "front": CAMERA_CANVAS_FRONT,
             "globe": CAMERA_CANVAS_GLOBE,
@@ -1118,8 +1153,6 @@ class LitterRobot5(LitterRobot):
             ImportError: If ``aiortc`` is not installed.
 
         """
-        from ..camera import CameraStream
-
         client = self.get_camera_client()
         return CameraStream(client)
 

--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -1108,7 +1108,7 @@ class LitterRobot5(LitterRobot):
         client = self.get_camera_client()
         return await client.set_camera_canvas(canvas)
 
-    def create_camera_stream(self, **kwargs: Any) -> CameraStream:
+    def create_camera_stream(self) -> CameraStream:
         """Create a ``CameraStream`` for live WebRTC streaming.
 
         Requires the ``aiortc`` optional dependency.
@@ -1121,7 +1121,7 @@ class LitterRobot5(LitterRobot):
         from ..camera import CameraStream
 
         client = self.get_camera_client()
-        return CameraStream(client, **kwargs)
+        return CameraStream(client)
 
     @classmethod
     async def fetch_for_account(cls, account: Account) -> list[dict[str, object]]:

--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -1076,7 +1076,7 @@ class LitterRobot5(LitterRobot):
 
         """
         client = self.get_camera_client()
-        return list(await client.get_videos(date=date, limit=limit))
+        return await client.get_videos(date=date, limit=limit)
 
     async def get_camera_video_settings(self) -> dict[str, Any] | None:
         """Fetch the camera's reported video settings."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+camera = ["aiortc>=1.9.0"]
+
 [project.urls]
 Homepage = "https://github.com/natekspencer/pylitterbot"
 Repository = "https://github.com/natekspencer/pylitterbot"

--- a/tests/common.py
+++ b/tests/common.py
@@ -353,6 +353,82 @@ LITTER_ROBOT_5_PRO_DATA: dict[str, Any] = {
     },
 }
 
+CAMERA_DEVICE_ID = "68f5f44bba1544a7cc8697c2"
+
+CAMERA_SESSION_RESPONSE: dict[str, Any] = {
+    "sessionId": "test-session-id-1234",
+    "sessionToken": "test-session-token-abcdef",
+    "sessionExpiration": "2025-12-31T23:59:59.000000Z",
+    "autoStart": False,
+    "signalingURL": "wss://watford.ienso-dev.com/api/signaling",
+    "turnServer": {
+        "username": "test-session-id-1234",
+        "password": "test-turn-password",
+        "stunUrl": "stun:coturn.watford-prod.ienso-dev.com:3478",
+        "turnUrl": ["turn:coturn.watford-prod.ienso-dev.com:443?transport=tcp"],
+    },
+}
+
+CAMERA_VIDEO_SETTINGS_RESPONSE: dict[str, Any] = {
+    "reportedSettings": [
+        {
+            "data": {
+                "streams": {
+                    "live-view": {
+                        "canvas": "sensor_0_1080p",
+                    }
+                }
+            }
+        }
+    ]
+}
+
+CAMERA_VIDEOS_RESPONSE: list[dict[str, Any]] = [
+    {
+        "id": 12345,
+        "videoThumbnail": "https://example.com/thumb1.jpg",
+        "eventType": "PET_VISIT",
+        "createdAt": 1735689600.0,
+        "hlsDuration": "00:19",
+        "allowForward": True,
+        "forwardingCountdownEndsAt": 1736000000.0,
+        "petDetections": [],
+    },
+    {
+        "id": 12346,
+        "videoThumbnail": "https://example.com/thumb2.jpg",
+        "eventType": "cat_detected",
+        "createdAt": 1735686000.0,
+        "hlsDuration": "01:05",
+        "allowForward": True,
+        "forwardingCountdownEndsAt": 1736000000.0,
+        "petDetections": ["pet-001"],
+    },
+]
+
+CAMERA_INFO_RESPONSE: dict[str, Any] = {
+    "deviceId": CAMERA_DEVICE_ID,
+    "serialNumber": "E0510076020EBFV",
+    "model": "LR5_PRO_CAMERA",
+    "status": "online",
+    "firmwareVersion": "1.2.2-1233",
+}
+
+CAMERA_EVENTS_RESPONSE: list[dict[str, Any]] = [
+    {
+        "eventId": "evt-001",
+        "type": "PET_VISIT",
+        "timestamp": "2025-12-01T12:00:00.000000Z",
+        "cameraId": CAMERA_DEVICE_ID,
+    },
+    {
+        "eventId": "evt-002",
+        "type": "MOTION",
+        "timestamp": "2025-12-01T11:00:00.000000Z",
+        "cameraId": CAMERA_DEVICE_ID,
+    },
+]
+
 FEEDER_ROBOT_DATA: dict[str, Any] = {
     "id": 1,
     "name": "Feeder-Robot",

--- a/tests/common.py
+++ b/tests/common.py
@@ -372,13 +372,37 @@ CAMERA_SESSION_RESPONSE: dict[str, Any] = {
 CAMERA_VIDEO_SETTINGS_RESPONSE: dict[str, Any] = {
     "reportedSettings": [
         {
+            "settingsType": "videoSettings",
             "data": {
                 "streams": {
                     "live-view": {
                         "canvas": "sensor_0_1080p",
                     }
                 }
-            }
+            },
+            "timestamp": "2026-06-10T18:30:45.375Z",
+        }
+    ]
+}
+
+CAMERA_AUDIO_SETTINGS_RESPONSE: dict[str, Any] = {
+    "reportedSettings": [
+        {
+            "settingsType": "audioSettings",
+            "data": {
+                "audio_in": {
+                    "global": {
+                        "mute": True,
+                        "volume": 79,
+                        "channels": 1,
+                        "latency_ms": 100,
+                        "sample_format": "int16",
+                        "sample_rate": 48000,
+                    }
+                },
+                "audio_out": {"volume": 69, "gain": 0, "mute": False},
+            },
+            "timestamp": "2026-06-10T18:30:45.375Z",
         }
     ]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from aioresponses import aioresponses
 from pycognito import TokenVerificationException
 
 from pylitterbot import Account
+from pylitterbot.camera import CAMERA_INVENTORY_API, CAMERA_SETTINGS_API, WATFORD_API
 from pylitterbot.pet import PET_PROFILE_ENDPOINT
 from pylitterbot.robot.feederrobot import FEEDER_ENDPOINT
 from pylitterbot.robot.litterrobot3 import DEFAULT_ENDPOINT
@@ -21,6 +22,12 @@ from pylitterbot.utils import urljoin
 
 from .common import (
     ACTIVITY_RESPONSE,
+    CAMERA_DEVICE_ID,
+    CAMERA_EVENTS_RESPONSE,
+    CAMERA_INFO_RESPONSE,
+    CAMERA_SESSION_RESPONSE,
+    CAMERA_VIDEO_SETTINGS_RESPONSE,
+    CAMERA_VIDEOS_RESPONSE,
     FEEDER_ROBOT_DATA,
     INSIGHT_RESPONSE,
     LITTER_ROBOT_4_DATA,
@@ -118,4 +125,59 @@ def mock_aioresponse() -> aioresponses:
             repeat=True,
         )
         mock.post(PET_PROFILE_ENDPOINT, payload={"data": {"getPetsByUser": [PET_DATA]}})
+        # Camera API mocks
+        mock.get(
+            re.compile(rf"{WATFORD_API}/api/device-manager/client/generate-session/.*"),
+            payload=CAMERA_SESSION_RESPONSE,
+            repeat=True,
+        )
+        mock.get(
+            re.compile(
+                rf"{re.escape(CAMERA_SETTINGS_API)}/prod/v1/cameras/.*/reported-settings/videoSettings"
+            ),
+            payload=CAMERA_VIDEO_SETTINGS_RESPONSE,
+            repeat=True,
+        )
+        mock.get(
+            re.compile(
+                rf"{re.escape(CAMERA_SETTINGS_API)}/prod/v1/cameras/.*/reported-settings/audioSettings"
+            ),
+            payload={"audioEnabled": False, "volume": 50},
+            repeat=True,
+        )
+        mock.patch(
+            re.compile(
+                rf"{re.escape(CAMERA_SETTINGS_API)}/prod/v1/cameras/.*/desired-settings/videoSettings"
+            ),
+            payload={},
+            repeat=True,
+        )
+        mock.patch(
+            re.compile(
+                rf"{re.escape(CAMERA_SETTINGS_API)}/prod/v1/cameras/.*/desired-settings/audioSettings"
+            ),
+            payload={},
+            repeat=True,
+        )
+        mock.get(
+            re.compile(
+                rf"{re.escape(CAMERA_INVENTORY_API)}/prod/v1/cameras/{CAMERA_DEVICE_ID}$"
+            ),
+            payload=CAMERA_INFO_RESPONSE,
+            repeat=True,
+        )
+        mock.get(
+            re.compile(
+                rf"{re.escape(CAMERA_INVENTORY_API)}/prod/v1/cameras/{CAMERA_DEVICE_ID}/videos"
+            ),
+            payload=CAMERA_VIDEOS_RESPONSE,
+            repeat=True,
+        )
+        mock.get(
+            re.compile(
+                rf"{re.escape(CAMERA_INVENTORY_API)}/prod/v1/cameras/{CAMERA_DEVICE_ID}/events"
+            ),
+            payload=CAMERA_EVENTS_RESPONSE,
+            repeat=True,
+        )
         yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from pylitterbot.utils import urljoin
 
 from .common import (
     ACTIVITY_RESPONSE,
+    CAMERA_AUDIO_SETTINGS_RESPONSE,
     CAMERA_DEVICE_ID,
     CAMERA_EVENTS_RESPONSE,
     CAMERA_INFO_RESPONSE,
@@ -143,7 +144,7 @@ def mock_aioresponse() -> aioresponses:
             re.compile(
                 rf"{re.escape(CAMERA_SETTINGS_API)}/prod/v1/cameras/.*/reported-settings/audioSettings"
             ),
-            payload={"audioEnabled": False, "volume": 50},
+            payload=CAMERA_AUDIO_SETTINGS_RESPONSE,
             repeat=True,
         )
         mock.patch(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,9 @@ def mock_aioresponse() -> aioresponses:
         )
         mock.post(PET_PROFILE_ENDPOINT, payload={"data": {"getPetsByUser": [PET_DATA]}})
         mock.get(
-            re.compile(rf"{WATFORD_API}/api/device-manager/client/generate-session/.*"),
+            re.compile(
+                rf"{re.escape(WATFORD_API)}/api/device-manager/client/generate-session/.*"
+            ),
             payload=CAMERA_SESSION_RESPONSE,
             repeat=True,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,6 @@ def mock_aioresponse() -> aioresponses:
             repeat=True,
         )
         mock.post(PET_PROFILE_ENDPOINT, payload={"data": {"getPetsByUser": [PET_DATA]}})
-        # Camera API mocks
         mock.get(
             re.compile(rf"{WATFORD_API}/api/device-manager/client/generate-session/.*"),
             payload=CAMERA_SESSION_RESPONSE,

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,0 +1,364 @@
+"""Test camera module."""
+
+# pylint: disable=protected-access
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aioresponses import aioresponses
+
+from pylitterbot import Account
+from pylitterbot.camera import (
+    CAMERA_CANVAS_FRONT,
+    CAMERA_CANVAS_GLOBE,
+    CameraClient,
+    CameraSession,
+    VideoClip,
+)
+from pylitterbot.exceptions import CameraNotAvailableException, InvalidCommandException
+from pylitterbot.robot.litterrobot5 import LitterRobot5
+
+from .common import (
+    CAMERA_DEVICE_ID,
+    CAMERA_EVENTS_RESPONSE,
+    CAMERA_INFO_RESPONSE,
+    CAMERA_SESSION_RESPONSE,
+    CAMERA_VIDEO_SETTINGS_RESPONSE,
+    CAMERA_VIDEOS_RESPONSE,
+    LITTER_ROBOT_5_DATA,
+    LITTER_ROBOT_5_PRO_DATA,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestCameraSession:
+    """Tests for CameraSession dataclass."""
+
+    def test_from_response(self) -> None:
+        """Test CameraSession creation from API response."""
+        session = CameraSession.from_response(CAMERA_SESSION_RESPONSE)
+        assert session.session_id == "test-session-id-1234"
+        assert session.session_token == "test-session-token-abcdef"
+        assert session.session_expiration is not None
+        assert session.signaling_url == "wss://watford.ienso-dev.com/api/signaling"
+        assert len(session.turn_servers) == 1
+        assert session.turn_servers[0]["username"] == "test-session-id-1234"
+        assert session.turn_servers[0]["password"] == "test-turn-password"
+        assert session.raw == CAMERA_SESSION_RESPONSE
+
+    def test_from_response_missing_fields(self) -> None:
+        """Test CameraSession with minimal/empty data."""
+        session = CameraSession.from_response({})
+        assert session.session_id == ""
+        assert session.session_token == ""
+        assert session.session_expiration is None
+        assert session.turn_servers == []
+
+    def test_from_response_dict_turn_creds(self) -> None:
+        """Test CameraSession when turnCredentials is a dict (not list)."""
+        data = {
+            **CAMERA_SESSION_RESPONSE,
+            "turnServer": None,
+            "turnCredentials": {
+                "urls": ["turn:example.com:443"],
+                "username": "u",
+                "credential": "c",
+            },
+        }
+        session = CameraSession.from_response(data)
+        assert len(session.turn_servers) == 1
+        assert session.turn_servers[0]["username"] == "u"
+
+    def test_from_response_ice_servers_key(self) -> None:
+        """Test CameraSession when iceServers is used instead of turnServer."""
+        data = {
+            "sessionId": "s1",
+            "sessionToken": "t1",
+            "iceServers": [
+                {"urls": "turn:ice.example.com", "username": "u", "credential": "c"}
+            ],
+        }
+        session = CameraSession.from_response(data)
+        assert len(session.turn_servers) == 1
+
+    def test_from_response_fallback_signaling_url(self) -> None:
+        """Test CameraSession builds signaling URL when not provided."""
+        data = {
+            "sessionId": "s1",
+            "sessionToken": "t1",
+        }
+        session = CameraSession.from_response(data)
+        assert "wss://" in session.signaling_url
+        assert "signaling" in session.signaling_url
+
+
+class TestVideoClip:
+    """Tests for VideoClip dataclass."""
+
+    def test_from_response(self) -> None:
+        """Test VideoClip creation from API response."""
+        clip = VideoClip.from_response(CAMERA_VIDEOS_RESPONSE[0])
+        assert clip.id == "12345"
+        assert clip.thumbnail_url == "https://example.com/thumb1.jpg"
+        assert clip.event_type == "PET_VISIT"
+        assert clip.created_at is not None
+        assert clip.raw == CAMERA_VIDEOS_RESPONSE[0]
+
+    def test_from_response_second_video(self) -> None:
+        """Test VideoClip creation from second response entry."""
+        clip = VideoClip.from_response(CAMERA_VIDEOS_RESPONSE[1])
+        assert clip.id == "12346"
+        assert clip.event_type == "cat_detected"
+        assert clip.thumbnail_url == "https://example.com/thumb2.jpg"
+
+    def test_from_response_empty(self) -> None:
+        """Test VideoClip with empty response."""
+        clip = VideoClip.from_response({})
+        assert clip.id == ""
+        assert clip.thumbnail_url is None
+        assert clip.event_type is None
+        assert clip.created_at is None
+
+
+class TestCameraClient:
+    """Tests for CameraClient REST API calls."""
+
+    async def test_generate_session(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test generating a camera session."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+        )
+        session = await client.generate_session()
+        assert isinstance(session, CameraSession)
+        assert session.session_id == "test-session-id-1234"
+        assert session.session_token == "test-session-token-abcdef"
+
+    async def test_get_video_settings(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test fetching video settings."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        settings = await client.get_video_settings()
+        assert settings is not None
+        assert "reportedSettings" in settings
+
+    async def test_set_camera_canvas(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test setting camera canvas."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        result = await client.set_camera_canvas(CAMERA_CANVAS_FRONT)
+        assert result is True
+
+    async def test_set_audio_enabled(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test setting audio enabled."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        result = await client.set_audio_enabled(True)
+        assert result is True
+
+    async def test_get_camera_info(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test fetching camera info."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        info = await client.get_camera_info()
+        assert info is not None
+        assert info["deviceId"] == CAMERA_DEVICE_ID
+
+    async def test_get_videos(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test fetching video clips."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        videos = await client.get_videos()
+        assert len(videos) == 2
+        assert isinstance(videos[0], VideoClip)
+        assert videos[0].id == "12345"
+
+    async def test_get_events(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test fetching camera events."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        events = await client.get_events(limit=10)
+        assert len(events) == 2
+        assert events[0]["eventId"] == "evt-001"
+
+    async def test_device_id_property(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test device_id property."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+        )
+        assert client.device_id == CAMERA_DEVICE_ID
+
+    async def test_settings_headers_with_api_key(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test that settings headers include x-api-key when provided."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="my-secret-key",
+        )
+        headers = client._settings_headers()
+        assert headers["x-api-key"] == "my-secret-key"
+
+    async def test_settings_headers_without_api_key(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test that settings headers are empty without api_key."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+        )
+        headers = client._settings_headers()
+        assert "x-api-key" not in headers
+
+
+class TestLitterRobot5Camera:
+    """Tests for LitterRobot5 camera convenience methods."""
+
+    async def test_has_camera_pro(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test has_camera returns True for Pro model."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        assert robot.has_camera is True
+
+    async def test_has_camera_standard(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test has_camera returns False for standard model."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_DATA, account=mock_account)
+        assert robot.has_camera is False
+
+    async def test_camera_metadata_pro(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test camera_metadata returns dict for Pro model."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        assert robot.camera_metadata is not None
+        assert robot.camera_metadata["deviceId"] == CAMERA_DEVICE_ID
+
+    async def test_get_camera_client(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test get_camera_client returns a CameraClient."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        client = robot.get_camera_client()
+        assert isinstance(client, CameraClient)
+        assert client.device_id == CAMERA_DEVICE_ID
+
+    async def test_get_camera_session(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test get_camera_session returns a CameraSession."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        session = await robot.get_camera_session()
+        assert isinstance(session, CameraSession)
+
+    async def test_get_camera_videos(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test get_camera_videos returns video clips."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        videos = await robot.get_camera_videos()
+        assert len(videos) == 2
+        assert isinstance(videos[0], VideoClip)
+
+    async def test_set_camera_view_front(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test set_camera_view with 'front'."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        result = await robot.set_camera_view("front")
+        assert result is True
+
+    async def test_set_camera_view_globe(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test set_camera_view with 'globe'."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        result = await robot.set_camera_view("globe")
+        assert result is True
+
+    async def test_set_camera_view_invalid(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test set_camera_view with invalid view name raises."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        with pytest.raises(InvalidCommandException, match="Invalid camera view"):
+            await robot.set_camera_view("rear")
+
+    async def test_no_camera_raises(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test get_camera_client raises for standard model."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_DATA, account=mock_account)
+        with pytest.raises(CameraNotAvailableException):
+            robot.get_camera_client()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -3,10 +3,14 @@
 # pylint: disable=protected-access
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from aiohttp import ClientResponseError, RequestInfo
 from aioresponses import aioresponses
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 
 from pylitterbot import Account
 from pylitterbot.camera import (
@@ -15,9 +19,16 @@ from pylitterbot.camera import (
     CameraClient,
     CameraSession,
     VideoClip,
+    _decode_sdp,
+    _parse_signaling_message,
 )
-from pylitterbot.exceptions import CameraNotAvailableException, InvalidCommandException
+from pylitterbot.exceptions import (
+    CameraNotAvailableException,
+    CameraStreamException,
+    InvalidCommandException,
+)
 from pylitterbot.robot.litterrobot5 import LitterRobot5
+from pylitterbot.utils import encode
 
 from .common import (
     CAMERA_DEVICE_ID,
@@ -153,7 +164,7 @@ class TestCameraClient:
             api_key="test-key",
         )
         settings = await client.get_video_settings()
-        assert settings == CAMERA_VIDEO_SETTINGS_RESPONSE
+        assert settings == CAMERA_VIDEO_SETTINGS_RESPONSE["reportedSettings"][0]["data"]
 
         await mock_account.disconnect()
 
@@ -170,7 +181,7 @@ class TestCameraClient:
         )
         settings = await client.get_audio_settings()
         assert settings is not None
-        assert "audioEnabled" in settings
+        assert settings["audio_in"]["global"]["mute"] is True
 
         await mock_account.disconnect()
 
@@ -449,5 +460,203 @@ class TestLitterRobot5Camera:
         robot = LitterRobot5(data=LITTER_ROBOT_5_DATA, account=mock_account)
         with pytest.raises(CameraNotAvailableException):
             robot.get_camera_client()
+
+        await robot._account.disconnect()
+
+
+class TestSignalingHelpers:
+    """Tests for the module-level signaling parse helpers."""
+
+    def test_parse_answer_base64(self) -> None:
+        """Test parsing a base64-encoded SDP answer."""
+        sdp = "v=0\r\no=- 1 1 IN IP4 0.0.0.0"
+        parsed = _parse_signaling_message({"type": "answer", "sdp": encode(sdp)})
+        assert parsed == ("answer", sdp)
+
+    def test_parse_answer_raw(self) -> None:
+        """Test parsing a raw (non-base64) SDP answer."""
+        sdp = "v=0\r\no=- 1 1 IN IP4 0.0.0.0"
+        parsed = _parse_signaling_message({"type": "answer", "payload": sdp})
+        assert parsed == ("answer", sdp)
+
+    def test_parse_candidate(self) -> None:
+        """Test parsing an ICE candidate message."""
+        parsed = _parse_signaling_message(
+            {"candidate": "candidate:1 1 udp 2 1.2.3.4 5 typ host", "sdpMid": "1"}
+        )
+        assert parsed is not None
+        kind, payload = parsed
+        assert kind == "candidate"
+        assert payload["sdpMid"] == "1"
+        assert payload["sdpMLineIndex"] == 0
+
+    def test_parse_candidate_null_fields(self) -> None:
+        """Test explicit JSON nulls for sdpMid/sdpMLineIndex get defaults."""
+        parsed = _parse_signaling_message(
+            {
+                "type": "candidate",
+                "candidate": "candidate:1 1 udp 2 1.2.3.4 5 typ host",
+                "sdpMid": None,
+                "sdpMLineIndex": None,
+            }
+        )
+        assert parsed is not None
+        _, payload = parsed
+        assert payload["sdpMid"] == "0"
+        assert payload["sdpMLineIndex"] == 0
+
+    def test_parse_empty_candidate(self) -> None:
+        """Test that an empty candidate string is ignored."""
+        assert _parse_signaling_message({"type": "candidate", "candidate": ""}) is None
+
+    def test_parse_unknown_message(self) -> None:
+        """Test that unknown message types are ignored."""
+        assert _parse_signaling_message({"type": "status", "ok": True}) is None
+
+    def test_decode_sdp_passthrough(self) -> None:
+        """Test that non-base64 input is passed through unchanged."""
+        assert _decode_sdp("not-base64!!") == "not-base64!!"
+        assert _decode_sdp("v=0 raw sdp") == "v=0 raw sdp"
+
+    def test_decode_sdp_base64_non_sdp(self) -> None:
+        """Test that base64 input not decoding to SDP is passed through raw."""
+        raw = encode("hello world")
+        assert _decode_sdp(raw) == raw
+
+    def test_ws_url_encodes_token(self) -> None:
+        """Test that the session token is URL-encoded in the ws URL."""
+        session = CameraSession(
+            session_id="s",
+            session_token="ab+c/d=",
+            session_expiration=None,
+            signaling_url="wss://host/sig",
+        )
+        assert session.ws_url == "wss://host/sig?accessToken=ab%2Bc%2Fd%3D"
+
+
+class TestCameraClientErrorFallbacks:
+    """Tests that API errors degrade per the documented contracts."""
+
+    @staticmethod
+    def _failing_session(error: Exception) -> Any:
+        session = SimpleNamespace()
+
+        async def _raise(*args: Any, **kwargs: Any) -> Any:
+            raise error
+
+        session.get = _raise
+        session.patch = _raise
+        return session
+
+    async def test_get_videos_invalid_command_returns_empty(self) -> None:
+        """Test HTTP 500 (InvalidCommandException) returns [] from get_videos."""
+        client = CameraClient(
+            session=self._failing_session(InvalidCommandException("server error")),
+            device_id=CAMERA_DEVICE_ID,
+        )
+        assert await client.get_videos() == []
+        assert await client.get_events() == []
+
+    async def test_get_video_settings_invalid_command_returns_none(self) -> None:
+        """Test HTTP 500 (InvalidCommandException) returns None from settings."""
+        client = CameraClient(
+            session=self._failing_session(InvalidCommandException("server error")),
+            device_id=CAMERA_DEVICE_ID,
+        )
+        assert await client.get_video_settings() is None
+        assert await client.get_audio_settings() is None
+        assert await client.get_camera_info() is None
+
+    async def test_set_audio_enabled_invalid_command_returns_false(self) -> None:
+        """Test HTTP 500 (InvalidCommandException) returns False from setters."""
+        client = CameraClient(
+            session=self._failing_session(InvalidCommandException("server error")),
+            device_id=CAMERA_DEVICE_ID,
+        )
+        assert await client.set_audio_enabled(True) is False
+        assert await client.set_camera_canvas(CAMERA_CANVAS_FRONT) is False
+
+    async def test_generate_session_wraps_invalid_command(self) -> None:
+        """Test generate_session wraps InvalidCommandException."""
+        client = CameraClient(
+            session=self._failing_session(InvalidCommandException("server error")),
+            device_id=CAMERA_DEVICE_ID,
+        )
+        with pytest.raises(CameraStreamException, match="Failed to generate"):
+            await client.generate_session()
+
+    async def test_generate_session_wraps_client_response_error(self) -> None:
+        """Test generate_session wraps ClientResponseError (e.g. 403)."""
+        request_info = RequestInfo(
+            url=URL("https://watford.example/session"),
+            method="GET",
+            headers=CIMultiDictProxy(CIMultiDict()),
+            real_url=URL("https://watford.example/session"),
+        )
+        error = ClientResponseError(
+            request_info=request_info, history=(), status=403, message="Forbidden"
+        )
+        client = CameraClient(
+            session=self._failing_session(error),
+            device_id=CAMERA_DEVICE_ID,
+        )
+        with pytest.raises(CameraStreamException, match="Failed to generate"):
+            await client.generate_session()
+
+
+class TestCameraAudioReconciliation:
+    """Tests for refresh_camera_audio_enabled."""
+
+    async def test_refresh_camera_audio_enabled(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test reconciling the audio cache from reported settings."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        # conftest serves CAMERA_AUDIO_SETTINGS_RESPONSE (mute: True) for
+        # reported audioSettings
+        assert await robot.refresh_camera_audio_enabled() is False
+        assert robot.camera_audio_enabled is False
+
+        await robot._account.disconnect()
+
+    async def test_refresh_camera_audio_unmuted(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test an unmuted reported-settings response enables the cache."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        client = robot.get_camera_client()
+
+        async def _settings(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "reportedSettings": [
+                    {
+                        "settingsType": "audioSettings",
+                        "data": {"audio_in": {"global": {"mute": False}}},
+                    }
+                ]
+            }
+
+        client._session = SimpleNamespace(get=_settings)  # type: ignore[assignment]
+        assert await robot.refresh_camera_audio_enabled() is True
+        assert robot.camera_audio_enabled is True
+
+        await robot._account.disconnect()
+
+    async def test_refresh_camera_audio_unknown_shape(
+        self,
+        mock_account: Account,
+    ) -> None:
+        """Test an unrecognized settings shape returns None and leaves cache."""
+        robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+        client = robot.get_camera_client()
+
+        async def _settings(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            return {"something": "else"}
+
+        client._session = SimpleNamespace(get=_settings)  # type: ignore[assignment]
+        assert await robot.refresh_camera_audio_enabled() is None
 
         await robot._account.disconnect()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -22,7 +22,6 @@ from pylitterbot.robot.litterrobot5 import LitterRobot5
 from .common import (
     CAMERA_DEVICE_ID,
     CAMERA_EVENTS_RESPONSE,
-    CAMERA_INFO_RESPONSE,
     CAMERA_SESSION_RESPONSE,
     CAMERA_VIDEO_SETTINGS_RESPONSE,
     CAMERA_VIDEOS_RESPONSE,
@@ -140,6 +139,8 @@ class TestCameraClient:
         assert session.session_id == "test-session-id-1234"
         assert session.session_token == "test-session-token-abcdef"
 
+        await mock_account.disconnect()
+
     async def test_get_video_settings(
         self,
         mock_account: Account,
@@ -152,8 +153,26 @@ class TestCameraClient:
             api_key="test-key",
         )
         settings = await client.get_video_settings()
+        assert settings == CAMERA_VIDEO_SETTINGS_RESPONSE
+
+        await mock_account.disconnect()
+
+    async def test_get_audio_settings(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test fetching audio settings."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        settings = await client.get_audio_settings()
         assert settings is not None
-        assert "reportedSettings" in settings
+        assert "audioEnabled" in settings
+
+        await mock_account.disconnect()
 
     async def test_set_camera_canvas(
         self,
@@ -169,6 +188,8 @@ class TestCameraClient:
         result = await client.set_camera_canvas(CAMERA_CANVAS_FRONT)
         assert result is True
 
+        await mock_account.disconnect()
+
     async def test_set_audio_enabled(
         self,
         mock_account: Account,
@@ -182,6 +203,8 @@ class TestCameraClient:
         )
         result = await client.set_audio_enabled(True)
         assert result is True
+
+        await mock_account.disconnect()
 
     async def test_get_camera_info(
         self,
@@ -197,6 +220,8 @@ class TestCameraClient:
         info = await client.get_camera_info()
         assert info is not None
         assert info["deviceId"] == CAMERA_DEVICE_ID
+
+        await mock_account.disconnect()
 
     async def test_get_videos(
         self,
@@ -214,6 +239,25 @@ class TestCameraClient:
         assert isinstance(videos[0], VideoClip)
         assert videos[0].id == "12345"
 
+        await mock_account.disconnect()
+
+    async def test_get_videos_with_limit(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test that get_videos enforces limit client-side."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        videos = await client.get_videos(limit=1)
+        assert len(videos) == 1
+        assert videos[0].id == str(CAMERA_VIDEOS_RESPONSE[0]["id"])
+
+        await mock_account.disconnect()
+
     async def test_get_events(
         self,
         mock_account: Account,
@@ -229,6 +273,25 @@ class TestCameraClient:
         assert len(events) == 2
         assert events[0]["eventId"] == "evt-001"
 
+        await mock_account.disconnect()
+
+    async def test_get_events_with_limit(
+        self,
+        mock_account: Account,
+        mock_aioresponse: aioresponses,
+    ) -> None:
+        """Test that get_events enforces limit client-side."""
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        events = await client.get_events(limit=1)
+        assert len(events) == 1
+        assert events[0]["eventId"] == CAMERA_EVENTS_RESPONSE[0]["eventId"]
+
+        await mock_account.disconnect()
+
     async def test_device_id_property(
         self,
         mock_account: Account,
@@ -239,6 +302,8 @@ class TestCameraClient:
             device_id=CAMERA_DEVICE_ID,
         )
         assert client.device_id == CAMERA_DEVICE_ID
+
+        await mock_account.disconnect()
 
     async def test_settings_headers_with_api_key(
         self,
@@ -253,6 +318,8 @@ class TestCameraClient:
         headers = client._settings_headers()
         assert headers["x-api-key"] == "my-secret-key"
 
+        await mock_account.disconnect()
+
     async def test_settings_headers_without_api_key(
         self,
         mock_account: Account,
@@ -264,6 +331,8 @@ class TestCameraClient:
         )
         headers = client._settings_headers()
         assert "x-api-key" not in headers
+
+        await mock_account.disconnect()
 
 
 class TestLitterRobot5Camera:
@@ -277,6 +346,8 @@ class TestLitterRobot5Camera:
         robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
         assert robot.has_camera is True
 
+        await robot._account.disconnect()
+
     async def test_has_camera_standard(
         self,
         mock_account: Account,
@@ -284,6 +355,8 @@ class TestLitterRobot5Camera:
         """Test has_camera returns False for standard model."""
         robot = LitterRobot5(data=LITTER_ROBOT_5_DATA, account=mock_account)
         assert robot.has_camera is False
+
+        await robot._account.disconnect()
 
     async def test_camera_metadata_pro(
         self,
@@ -293,6 +366,8 @@ class TestLitterRobot5Camera:
         robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
         assert robot.camera_metadata is not None
         assert robot.camera_metadata["deviceId"] == CAMERA_DEVICE_ID
+
+        await robot._account.disconnect()
 
     async def test_get_camera_client(
         self,
@@ -304,6 +379,8 @@ class TestLitterRobot5Camera:
         assert isinstance(client, CameraClient)
         assert client.device_id == CAMERA_DEVICE_ID
 
+        await robot._account.disconnect()
+
     async def test_get_camera_session(
         self,
         mock_account: Account,
@@ -313,6 +390,8 @@ class TestLitterRobot5Camera:
         robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
         session = await robot.get_camera_session()
         assert isinstance(session, CameraSession)
+
+        await robot._account.disconnect()
 
     async def test_get_camera_videos(
         self,
@@ -325,6 +404,8 @@ class TestLitterRobot5Camera:
         assert len(videos) == 2
         assert isinstance(videos[0], VideoClip)
 
+        await robot._account.disconnect()
+
     async def test_set_camera_view_front(
         self,
         mock_account: Account,
@@ -334,6 +415,8 @@ class TestLitterRobot5Camera:
         robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
         result = await robot.set_camera_view("front")
         assert result is True
+
+        await robot._account.disconnect()
 
     async def test_set_camera_view_globe(
         self,
@@ -345,6 +428,8 @@ class TestLitterRobot5Camera:
         result = await robot.set_camera_view("globe")
         assert result is True
 
+        await robot._account.disconnect()
+
     async def test_set_camera_view_invalid(
         self,
         mock_account: Account,
@@ -354,6 +439,8 @@ class TestLitterRobot5Camera:
         with pytest.raises(InvalidCommandException, match="Invalid camera view"):
             await robot.set_camera_view("rear")
 
+        await robot._account.disconnect()
+
     async def test_no_camera_raises(
         self,
         mock_account: Account,
@@ -362,3 +449,5 @@ class TestLitterRobot5Camera:
         robot = LitterRobot5(data=LITTER_ROBOT_5_DATA, account=mock_account)
         with pytest.raises(CameraNotAvailableException):
             robot.get_camera_client()
+
+        await robot._account.disconnect()

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -467,17 +467,43 @@ class TestLitterRobot5Camera:
 class TestSignalingHelpers:
     """Tests for the module-level signaling parse helpers."""
 
+    ANSWER_SDP = (
+        "v=0\r\no=- 1 1 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\n"
+        "m=video 9 UDP/TLS/RTP/SAVPF 96"
+    )
+
     def test_parse_answer_base64(self) -> None:
         """Test parsing a base64-encoded SDP answer."""
-        sdp = "v=0\r\no=- 1 1 IN IP4 0.0.0.0"
-        parsed = _parse_signaling_message({"type": "answer", "sdp": encode(sdp)})
-        assert parsed == ("answer", sdp)
+        parsed = _parse_signaling_message(
+            {"type": "answer", "sdp": encode(self.ANSWER_SDP)}
+        )
+        assert parsed == ("answer", self.ANSWER_SDP)
 
     def test_parse_answer_raw(self) -> None:
         """Test parsing a raw (non-base64) SDP answer."""
-        sdp = "v=0\r\no=- 1 1 IN IP4 0.0.0.0"
-        parsed = _parse_signaling_message({"type": "answer", "payload": sdp})
-        assert parsed == ("answer", sdp)
+        parsed = _parse_signaling_message(
+            {"type": "answer", "payload": self.ANSWER_SDP}
+        )
+        assert parsed == ("answer", self.ANSWER_SDP)
+
+    def test_parse_answer_truncated(self) -> None:
+        r"""Test that a truncated answer SDP is discarded.
+
+        Observed live: the camera occasionally sends an answer payload that
+        decodes to just ``"v=0\r\n"``, which the peer's SDP parser rejects
+        ("Expect line: o=").
+        """
+        assert (
+            _parse_signaling_message({"type": "answer", "payload": encode("v=0\r\n")})
+            is None
+        )
+        assert _parse_signaling_message({"type": "answer", "payload": ""}) is None
+        assert (
+            _parse_signaling_message(
+                {"type": "answer", "payload": "v=0\r\no=- 1 1 IN IP4 0.0.0.0"}
+            )
+            is None
+        )
 
     def test_parse_candidate(self) -> None:
         """Test parsing an ICE candidate message."""

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -1007,14 +1007,24 @@ async def test_litter_robot_5_set_camera_audio(
     mock_aioresponse: aioresponses,
     mock_account: Account,
 ) -> None:
-    """Tests toggling camera audio."""
+    """Tests toggling camera audio via camera API."""
+    robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
+
+    result = await robot.set_camera_audio(True)
+    assert result
+    assert robot.camera_audio_enabled
+
+    result = await robot.set_camera_audio(False)
+    assert result
+    assert not robot.camera_audio_enabled
+
+
+async def test_litter_robot_5_set_camera_audio_no_camera(
+    mock_account: Account,
+) -> None:
+    """Tests that set_camera_audio returns False for robots without camera."""
     robot = LitterRobot5(data=LITTER_ROBOT_5_DATA, account=mock_account)
-
-    mock_aioresponse.patch(LR5_GET_URL, payload={})
-    assert await robot.set_camera_audio(True)
-
-    mock_aioresponse.patch(LR5_GET_URL, payload={})
-    assert await robot.set_camera_audio(False)
+    assert await robot.set_camera_audio(True) is False
 
     await robot._account.disconnect()
 

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -1018,6 +1018,8 @@ async def test_litter_robot_5_set_camera_audio(
     assert result
     assert not robot.camera_audio_enabled
 
+    await robot._account.disconnect()
+
 
 async def test_litter_robot_5_set_camera_audio_no_camera(
     mock_account: Account,

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -1010,12 +1010,8 @@ async def test_litter_robot_5_set_camera_audio(
     """Tests toggling camera audio via camera API."""
     robot = LitterRobot5(data=LITTER_ROBOT_5_PRO_DATA, account=mock_account)
 
-    result = await robot.set_camera_audio(True)
-    assert result
-    assert robot.camera_audio_enabled
-
-    result = await robot.set_camera_audio(False)
-    assert result
+    assert await robot.set_camera_audio(True)
+    assert await robot.set_camera_audio(False)
     assert not robot.camera_audio_enabled
 
     await robot._account.disconnect()

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -14,7 +14,11 @@ from yarl import URL
 
 from pylitterbot import Account
 from pylitterbot.enums import GlobeMotorFaultStatus, LitterBoxStatus
-from pylitterbot.exceptions import InvalidCommandException, LitterRobotException
+from pylitterbot.exceptions import (
+    CameraNotAvailableException,
+    InvalidCommandException,
+    LitterRobotException,
+)
 from pylitterbot.robot.litterrobot5 import (
     LITTER_LEVEL_EMPTY,
     LR5_ENDPOINT,
@@ -1020,9 +1024,10 @@ async def test_litter_robot_5_set_camera_audio(
 async def test_litter_robot_5_set_camera_audio_no_camera(
     mock_account: Account,
 ) -> None:
-    """Tests that set_camera_audio returns False for robots without camera."""
+    """Tests that set_camera_audio raises for robots without a camera."""
     robot = LitterRobot5(data=LITTER_ROBOT_5_DATA, account=mock_account)
-    assert await robot.set_camera_audio(True) is False
+    with pytest.raises(CameraNotAvailableException):
+        await robot.set_camera_audio(True)
 
     await robot._account.disconnect()
 

--- a/uv.lock
+++ b/uv.lock
@@ -132,6 +132,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aioice"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/04/df7286233f468e19e9bedff023b6b246182f0b2ccb04ceeb69b2994021c6/aioice-0.10.2.tar.gz", hash = "sha256:bf236c6829ee33c8e540535d31cd5a066b531cb56de2be94c46be76d68b1a806", size = 44307, upload-time = "2025-11-28T15:56:48.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e3/0d23b1f930c17d371ce1ec36ee529f22fd19ebc2a07fe3418e3d1d884ce2/aioice-0.10.2-py3-none-any.whl", hash = "sha256:14911c15ab12d096dd14d372ebb4aecbb7420b52c9b76fdfcf54375dec17fcbf", size = 24875, upload-time = "2025-11-28T15:56:47.847Z" },
+]
+
+[[package]]
 name = "aioresponses"
 version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
@@ -142,6 +155,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/03/532bbc645bdebcf3b6af3b25d46655259d66ce69abba7720b71ebfabbade/aioresponses-0.7.8.tar.gz", hash = "sha256:b861cdfe5dc58f3b8afac7b0a6973d5d7b2cb608dd0f6253d16b8ee8eaf6df11", size = 40253, upload-time = "2025-01-19T18:14:03.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b7/584157e43c98aa89810bc2f7099e7e01c728ecf905a66cf705106009228f/aioresponses-0.7.8-py2.py3-none-any.whl", hash = "sha256:b73bd4400d978855e55004b23a3a84cb0f018183bcf066a85ad392800b5b9a94", size = 12518, upload-time = "2025-01-19T18:13:59.633Z" },
+]
+
+[[package]]
+name = "aiortc"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aioice" },
+    { name = "av" },
+    { name = "cryptography" },
+    { name = "google-crc32c" },
+    { name = "pyee" },
+    { name = "pylibsrtp" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/9c/4e027bfe0195de0442da301e2389329496745d40ae44d2d7c4571c4290ce/aiortc-1.14.0.tar.gz", hash = "sha256:adc8a67ace10a085721e588e06a00358ed8eaf5f6b62f0a95358ff45628dd762", size = 1180864, upload-time = "2025-10-13T21:40:37.905Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ab/31646a49209568cde3b97eeade0d28bb78b400e6645c56422c101df68932/aiortc-1.14.0-py3-none-any.whl", hash = "sha256:4b244d7e482f4e1f67e685b3468269628eca1ec91fa5b329ab517738cfca086e", size = 93183, upload-time = "2025-10-13T21:40:36.59Z" },
 ]
 
 [[package]]
@@ -173,6 +204,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30", size = 780820, upload-time = "2023-12-31T06:30:32.926Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1", size = 60752, upload-time = "2023-12-31T06:30:30.772Z" },
+]
+
+[[package]]
+name = "av"
+version = "16.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/cd/3a83ffbc3cc25b39721d174487fb0d51a76582f4a1703f98e46170ce83d4/av-16.1.0.tar.gz", hash = "sha256:a094b4fd87a3721dacf02794d3d2c82b8d712c85b9534437e82a8a978c175ffd", size = 4285203, upload-time = "2026-01-11T07:31:33.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/51/2217a9249409d2e88e16e3f16f7c0def9fd3e7ffc4238b2ec211f9935bdb/av-16.1.0-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:2395748b0c34fe3a150a1721e4f3d4487b939520991b13e7b36f8926b3b12295", size = 26942590, upload-time = "2026-01-09T20:17:58.588Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/cd/a7070f4febc76a327c38808e01e2ff6b94531fe0b321af54ea3915165338/av-16.1.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:72d7ac832710a158eeb7a93242370aa024a7646516291c562ee7f14a7ea881fd", size = 21507910, upload-time = "2026-01-09T20:18:02.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/30/ec812418cd9b297f0238fe20eb0747d8a8b68d82c5f73c56fe519a274143/av-16.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:6cbac833092e66b6b0ac4d81ab077970b8ca874951e9c3974d41d922aaa653ed", size = 38738309, upload-time = "2026-01-09T20:18:04.701Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b8/6c5795bf1f05f45c5261f8bce6154e0e5e86b158a6676650ddd77c28805e/av-16.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:eb990672d97c18f99c02f31c8d5750236f770ffe354b5a52c5f4d16c5e65f619", size = 40293006, upload-time = "2026-01-09T20:18:07.238Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/44/5e183bcb9333fc3372ee6e683be8b0c9b515a506894b2d32ff465430c074/av-16.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:05ad70933ac3b8ef896a820ea64b33b6cca91a5fac5259cb9ba7fa010435be15", size = 40123516, upload-time = "2026-01-09T20:18:09.955Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1d/b5346d582a3c3d958b4d26a2cc63ce607233582d956121eb20d2bbe55c2e/av-16.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d831a1062a3c47520bf99de6ec682bd1d64a40dfa958e5457bb613c5270e7ce3", size = 41463289, upload-time = "2026-01-09T20:18:12.459Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/31/acc946c0545f72b8d0d74584cb2a0ade9b7dfe2190af3ef9aa52a2e3c0b1/av-16.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:358ab910fef3c5a806c55176f2b27e5663b33c4d0a692dafeb049c6ed71f8aff", size = 31754959, upload-time = "2026-01-09T20:18:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d0/b71b65d1b36520dcb8291a2307d98b7fc12329a45614a303ff92ada4d723/av-16.1.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:e88ad64ee9d2b9c4c5d891f16c22ae78e725188b8926eb88187538d9dd0b232f", size = 26927747, upload-time = "2026-01-09T20:18:16.976Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/79/720a5a6ccdee06eafa211b945b0a450e3a0b8fc3d12922f0f3c454d870d2/av-16.1.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:cb296073fa6935724de72593800ba86ae49ed48af03960a4aee34f8a611f442b", size = 21492232, upload-time = "2026-01-09T20:18:19.266Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/4f/a1ba8d922f2f6d1a3d52419463ef26dd6c4d43ee364164a71b424b5ae204/av-16.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:720edd4d25aa73723c1532bb0597806d7b9af5ee34fc02358782c358cfe2f879", size = 39291737, upload-time = "2026-01-09T20:18:21.513Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/31/fc62b9fe8738d2693e18d99f040b219e26e8df894c10d065f27c6b4f07e3/av-16.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:c7f2bc703d0df260a1fdf4de4253c7f5500ca9fc57772ea241b0cb241bcf972e", size = 40846822, upload-time = "2026-01-09T20:18:24.275Z" },
+    { url = "https://files.pythonhosted.org/packages/53/10/ab446583dbce730000e8e6beec6ec3c2753e628c7f78f334a35cad0317f4/av-16.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d69c393809babada7d54964d56099e4b30a3e1f8b5736ca5e27bd7be0e0f3c83", size = 40675604, upload-time = "2026-01-09T20:18:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d7/1003be685277005f6d63fd9e64904ee222fe1f7a0ea70af313468bb597db/av-16.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:441892be28582356d53f282873c5a951592daaf71642c7f20165e3ddcb0b4c63", size = 42015955, upload-time = "2026-01-09T20:18:29.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/4a/fa2a38ee9306bf4579f556f94ecbc757520652eb91294d2a99c7cf7623b9/av-16.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:273a3e32de64819e4a1cd96341824299fe06f70c46f2288b5dc4173944f0fd62", size = 31750339, upload-time = "2026-01-09T20:18:32.249Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/84/2535f55edcd426cebec02eb37b811b1b0c163f26b8d3f53b059e2ec32665/av-16.1.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:640f57b93f927fba8689f6966c956737ee95388a91bd0b8c8b5e0481f73513d6", size = 26945785, upload-time = "2026-01-09T20:18:34.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/17/ffb940c9e490bf42e86db4db1ff426ee1559cd355a69609ec1efe4d3a9eb/av-16.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ae3fb658eec00852ebd7412fdc141f17f3ddce8afee2d2e1cf366263ad2a3b35", size = 21481147, upload-time = "2026-01-09T20:18:36.716Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c1/e0d58003d2d83c3921887d5c8c9b8f5f7de9b58dc2194356a2656a45cfdc/av-16.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ee558d9c02a142eebcbe55578a6d817fedfde42ff5676275504e16d07a7f86", size = 39517197, upload-time = "2026-01-11T09:57:31.937Z" },
+    { url = "https://files.pythonhosted.org/packages/32/77/787797b43475d1b90626af76f80bfb0c12cfec5e11eafcfc4151b8c80218/av-16.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7ae547f6d5fa31763f73900d43901e8c5fa6367bb9a9840978d57b5a7ae14ed2", size = 41174337, upload-time = "2026-01-11T09:57:35.792Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/d90df7f1e3b97fc5554cf45076df5045f1e0a6adf13899e10121229b826c/av-16.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8cf065f9d438e1921dc31fc7aa045790b58aee71736897866420d80b5450f62a", size = 40817720, upload-time = "2026-01-11T09:57:39.039Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6f/13c3a35f9dbcebafd03fe0c4cbd075d71ac8968ec849a3cfce406c35a9d2/av-16.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a345877a9d3cc0f08e2bc4ec163ee83176864b92587afb9d08dff50f37a9a829", size = 42267396, upload-time = "2026-01-11T09:57:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b9/275df9607f7fb44317ccb1d4be74827185c0d410f52b6e2cd770fe209118/av-16.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:f49243b1d27c91cd8c66fdba90a674e344eb8eb917264f36117bf2b6879118fd", size = 31752045, upload-time = "2026-01-11T09:57:45.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2a/63797a4dde34283dd8054219fcb29294ba1c25d68ba8c8c8a6ae53c62c45/av-16.1.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:ce2a1b3d8bf619f6c47a9f28cfa7518ff75ddd516c234a4ee351037b05e6a587", size = 26916715, upload-time = "2026-01-11T09:57:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c4/0b49cf730d0ae8cda925402f18ae814aef351f5772d14da72dd87ff66448/av-16.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:408dbe6a2573ca58a855eb8cd854112b33ea598651902c36709f5f84c991ed8e", size = 21452167, upload-time = "2026-01-11T09:57:50.606Z" },
+    { url = "https://files.pythonhosted.org/packages/51/23/408806503e8d5d840975aad5699b153aaa21eb6de41ade75248a79b7a37f/av-16.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:57f657f86652a160a8a01887aaab82282f9e629abf94c780bbdbb01595d6f0f7", size = 39215659, upload-time = "2026-01-11T09:57:53.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/19/a8528d5bba592b3903f44c28dab9cc653c95fcf7393f382d2751a1d1523e/av-16.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:adbad2b355c2ee4552cac59762809d791bda90586d134a33c6f13727fb86cb3a", size = 40874970, upload-time = "2026-01-11T09:57:56.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/24/2dbcdf0e929ad56b7df078e514e7bd4ca0d45cba798aff3c8caac097d2f7/av-16.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f42e1a68ec2aebd21f7eb6895be69efa6aa27eec1670536876399725bbda4b99", size = 40530345, upload-time = "2026-01-11T09:58:00.421Z" },
+    { url = "https://files.pythonhosted.org/packages/54/27/ae91b41207f34e99602d1c72ab6ffd9c51d7c67e3fbcd4e3a6c0e54f882c/av-16.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58fe47aeaef0f100c40ec8a5de9abbd37f118d3ca03829a1009cf288e9aef67c", size = 41972163, upload-time = "2026-01-11T09:58:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7a/22158fb923b2a9a00dfab0e96ef2e8a1763a94dd89e666a5858412383d46/av-16.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:565093ebc93b2f4b76782589564869dadfa83af5b852edebedd8fee746457d06", size = 31729230, upload-time = "2026-01-11T09:58:07.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f1/878f8687d801d6c4565d57ebec08449c46f75126ebca8e0fed6986599627/av-16.1.0-cp313-cp313t-macosx_11_0_x86_64.whl", hash = "sha256:574081a24edb98343fd9f473e21ae155bf61443d4ec9d7708987fa597d6b04b2", size = 27008769, upload-time = "2026-01-11T09:58:10.266Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f1/bd4ce8c8b5cbf1d43e27048e436cbc9de628d48ede088a1d0a993768eb86/av-16.1.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:9ab00ea29c25ebf2ea1d1e928d7babb3532d562481c5d96c0829212b70756ad0", size = 21590588, upload-time = "2026-01-11T09:58:12.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/c81f6f9209201ff0b5d5bed6da6c6e641eef52d8fbc930d738c3f4f6f75d/av-16.1.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:a84a91188c1071f238a9523fd42dbe567fb2e2607b22b779851b2ce0eac1b560", size = 40638029, upload-time = "2026-01-11T09:58:15.399Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4d/07edff82b78d0459a6e807e01cd280d3180ce832efc1543de80d77676722/av-16.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c2cd0de4dd022a7225ff224fde8e7971496d700be41c50adaaa26c07bb50bf97", size = 41970776, upload-time = "2026-01-11T09:58:19.075Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9d/1f48b354b82fa135d388477cd1b11b81bdd4384bd6a42a60808e2ec2d66b/av-16.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0816143530624a5a93bc5494f8c6eeaf77549b9366709c2ac8566c1e9bff6df5", size = 41764751, upload-time = "2026-01-11T09:58:22.788Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c7/a509801e98db35ec552dd79da7bdbcff7104044bfeb4c7d196c1ce121593/av-16.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e3a28053af29644696d0c007e897d19b1197585834660a54773e12a40b16974c", size = 43034355, upload-time = "2026-01-11T09:58:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8b/e5f530d9e8f640da5f5c5f681a424c65f9dd171c871cd255d8a861785a6e/av-16.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e3e67144a202b95ed299d165232533989390a9ea3119d37eccec697dc6dbb0c", size = 31947047, upload-time = "2026-01-11T09:58:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/df/18/8812221108c27d19f7e5f486a82c827923061edf55f906824ee0fcaadf50/av-16.1.0-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:39a634d8e5a87e78ea80772774bfd20c0721f0d633837ff185f36c9d14ffede4", size = 26916179, upload-time = "2026-01-11T09:58:36.506Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ef/49d128a9ddce42a2766fe2b6595bd9c49e067ad8937a560f7838a541464e/av-16.1.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0ba32fb9e9300948a7fa9f8a3fc686e6f7f77599a665c71eb2118fdfd2c743f9", size = 21460168, upload-time = "2026-01-11T09:58:39.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a9/b310d390844656fa74eeb8c2750e98030877c75b97551a23a77d3f982741/av-16.1.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ca04d17815182d34ce3edc53cbda78a4f36e956c0fd73e3bab249872a831c4d7", size = 39210194, upload-time = "2026-01-11T09:58:42.138Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7b/e65aae179929d0f173af6e474ad1489b5b5ad4c968a62c42758d619e54cf/av-16.1.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ee0e8de2e124a9ef53c955fe2add6ee7c56cc8fd83318265549e44057db77142", size = 40811675, upload-time = "2026-01-11T09:58:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/5d7edefd26b6a5187d6fac0f5065ee286109934f3dea607ef05e53f05b31/av-16.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:22bf77a2f658827043a1e184b479c3bf25c4c43ab32353677df2d119f080e28f", size = 40543942, upload-time = "2026-01-11T09:58:49.759Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/f8b17897b67be0900a211142f5646a99d896168f54d57c81f3e018853796/av-16.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2dd419d262e6a71cab206d80bbf28e0a10d0f227b671cdf5e854c028faa2d043", size = 41924336, upload-time = "2026-01-11T09:58:53.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/d32bc6bbbcf60b65f6510c54690ed3ae1c4ca5d9fafbce835b6056858686/av-16.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:53585986fd431cd436f290fba662cfb44d9494fbc2949a183de00acc5b33fa88", size = 31735077, upload-time = "2026-01-11T09:58:56.684Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f4/9b63dc70af8636399bd933e9df4f3025a0294609510239782c1b746fc796/av-16.1.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:76f5ed8495cf41e1209a5775d3699dc63fdc1740b94a095e2485f13586593205", size = 27014423, upload-time = "2026-01-11T09:58:59.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/da/787a07a0d6ed35a0888d7e5cfb8c2ffa202f38b7ad2c657299fac08eb046/av-16.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:8d55397190f12a1a3ae7538be58c356cceb2bf50df1b33523817587748ce89e5", size = 21595536, upload-time = "2026-01-11T09:59:02.508Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f4/9a7d8651a611be6e7e3ab7b30bb43779899c8cac5f7293b9fb634c44a3f3/av-16.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9d51d9037437218261b4bbf9df78a95e216f83d7774fbfe8d289230b5b2e28e2", size = 40642490, upload-time = "2026-01-11T09:59:05.842Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e4/eb79bc538a94b4ff93cd4237d00939cba797579f3272490dd0144c165a21/av-16.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0ce07a89c15644407f49d942111ca046e323bbab0a9078ff43ee57c9b4a50dad", size = 41976905, upload-time = "2026-01-11T09:59:09.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/f6db0dd86b70167a4d55ee0d9d9640983c570d25504f2bde42599f38241e/av-16.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cac0c074892ea97113b53556ff41c99562db7b9f09f098adac1f08318c2acad5", size = 41770481, upload-time = "2026-01-11T09:59:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/33651d658e45e16ab7671ea5fcf3d20980ea7983234f4d8d0c63c65581a5/av-16.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7dec3dcbc35a187ce450f65a2e0dda820d5a9e6553eea8344a1459af11c98649", size = 43036824, upload-time = "2026-01-11T09:59:16.507Z" },
+    { url = "https://files.pythonhosted.org/packages/83/41/7f13361db54d7e02f11552575c0384dadaf0918138f4eaa82ea03a9f9580/av-16.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6f90dc082ff2068ddbe77618400b44d698d25d9c4edac57459e250c16b33d700", size = 31948164, upload-time = "2026-01-11T09:59:19.501Z" },
 ]
 
 [[package]]
@@ -570,6 +658,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "envs"
 version = "1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -663,6 +760,41 @@ wheels = [
 ]
 
 [[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/ac/6f7bc93886a823ab545948c2dd48143027b2355ad1944c7cf852b338dc91/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:0470b8c3d73b5f4e3300165498e4cf25221c7eb37f1159e221d1825b6df8a7ff", size = 31296, upload-time = "2025-12-16T00:19:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/97/a5accde175dee985311d949cfcb1249dcbb290f5ec83c994ea733311948f/google_crc32c-1.8.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:119fcd90c57c89f30040b47c211acee231b25a45d225e3225294386f5d258288", size = 30870, upload-time = "2025-12-16T00:29:17.669Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/63/bec827e70b7a0d4094e7476f863c0dbd6b5f0f1f91d9c9b32b76dcdfeb4e/google_crc32c-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6f35aaffc8ccd81ba3162443fabb920e65b1f20ab1952a31b13173a67811467d", size = 33214, upload-time = "2025-12-16T00:40:19.618Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/11b70614df04c289128d782efc084b9035ef8466b3d0a8757c1b6f5cf7ac/google_crc32c-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:864abafe7d6e2c4c66395c1eb0fe12dc891879769b52a3d56499612ca93b6092", size = 33589, upload-time = "2025-12-16T00:40:20.7Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/00/a08a4bc24f1261cc5b0f47312d8aebfbe4b53c2e6307f1b595605eed246b/google_crc32c-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:db3fe8eaf0612fc8b20fa21a5f25bd785bc3cd5be69f8f3412b0ac2ffd49e733", size = 34437, upload-time = "2025-12-16T00:35:19.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ef/21ccfaab3d5078d41efe8612e0ed0bfc9ce22475de074162a91a25f7980d/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:014a7e68d623e9a4222d663931febc3033c5c7c9730785727de2a81f87d5bab8", size = 31298, upload-time = "2025-12-16T00:20:32.241Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b8/f8413d3f4b676136e965e764ceedec904fe38ae8de0cdc52a12d8eb1096e/google_crc32c-1.8.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:86cfc00fe45a0ac7359e5214a1704e51a99e757d0272554874f419f79838c5f7", size = 30872, upload-time = "2025-12-16T00:33:58.785Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fd/33aa4ec62b290477181c55bb1c9302c9698c58c0ce9a6ab4874abc8b0d60/google_crc32c-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:19b40d637a54cb71e0829179f6cb41835f0fbd9e8eb60552152a8b52c36cbe15", size = 33243, upload-time = "2025-12-16T00:40:21.46Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/4820b3bd99c9653d1a5210cb32f9ba4da9681619b4d35b6a052432df4773/google_crc32c-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:17446feb05abddc187e5441a45971b8394ea4c1b6efd88ab0af393fd9e0a156a", size = 33608, upload-time = "2025-12-16T00:40:22.204Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/43/acf61476a11437bf9733fb2f70599b1ced11ec7ed9ea760fdd9a77d0c619/google_crc32c-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:71734788a88f551fbd6a97be9668a0020698e07b2bf5b3aa26a36c10cdfb27b2", size = 34439, upload-time = "2025-12-16T00:35:20.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+    { url = "https://files.pythonhosted.org/packages/52/c5/c171e4d8c44fec1422d801a6d2e5d7ddabd733eeda505c79730ee9607f07/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:87fa445064e7db928226b2e6f0d5304ab4cd0339e664a4e9a25029f384d9bb93", size = 28615, upload-time = "2025-12-16T00:40:29.298Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/97/7d75fe37a7a6ed171a2cf17117177e7aab7e6e0d115858741b41e9dd4254/google_crc32c-1.8.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f639065ea2042d5c034bf258a9f085eaa7af0cd250667c0635a3118e8f92c69c", size = 28800, upload-time = "2025-12-16T00:40:30.322Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.8"
 source = { registry = "https://pypi.org/simple" }
@@ -678,6 +810,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/ed/f86a79a07470cb07819390452f178b3bef1d375f2ec021ecfc709fc7cf07/idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc", size = 189575, upload-time = "2024-04-11T03:34:43.276Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0", size = 66836, upload-time = "2024-04-11T03:34:41.447Z" },
+]
+
+[[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
 ]
 
 [[package]]
@@ -1088,6 +1229,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1114,6 +1267,28 @@ crypto = [
 ]
 
 [[package]]
+name = "pylibsrtp"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a6/6e532bec974aaecbf9fe4e12538489fb1c28456e65088a50f305aeab9f89/pylibsrtp-1.0.0.tar.gz", hash = "sha256:b39dff075b263a8ded5377f2490c60d2af452c9f06c4d061c7a2b640612b34d4", size = 10858, upload-time = "2025-10-13T16:12:31.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/af/89e61a62fa3567f1b7883feb4d19e19564066c2fcd41c37e08d317b51881/pylibsrtp-1.0.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:822c30ea9e759b333dc1f56ceac778707c51546e97eb874de98d7d378c000122", size = 1865017, upload-time = "2025-10-13T16:12:15.62Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0e/8d215484a9877adcf2459a8b28165fc89668b034565277fd55d666edd247/pylibsrtp-1.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:aaad74e5c8cbc1c32056c3767fea494c1e62b3aea2c908eda2a1051389fdad76", size = 2182739, upload-time = "2025-10-13T16:12:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/57/3f/76a841978877ae13eac0d4af412c13bbd5d83b3df2c1f5f2175f2e0f68e5/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9209b86e662ebbd17c8a9e8549ba57eca92a3e87fb5ba8c0e27b8c43cd08a767", size = 2732922, upload-time = "2025-10-13T16:12:18.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/14/cf5d2a98a66fdfe258f6b036cda570f704a644fa861d7883a34bc359501e/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:293c9f2ac21a2bd689c477603a1aa235d85cf252160e6715f0101e42a43cbedc", size = 2434534, upload-time = "2025-10-13T16:12:20.074Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/08/a3f6e86c04562f7dce6717cd2206a0f84ca85c5e38121d998e0e330194c3/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:81fb8879c2e522021a7cbd3f4bda1b37c192e1af939dfda3ff95b4723b329663", size = 2345818, upload-time = "2025-10-13T16:12:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d5/130c2b5b4b51df5631684069c6f0a6761c59d096a33d21503ac207cf0e47/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4ddb562e443cf2e557ea2dfaeef0d7e6b90e96dd38eb079b4ab2c8e34a79f50b", size = 2774490, upload-time = "2025-10-13T16:12:22.659Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e3/715a453bfee3bea92a243888ad359094a7727cc6d393f21281320fe7798c/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:f02e616c9dfab2b03b32d8cc7b748f9d91814c0211086f987629a60f05f6e2cc", size = 2372603, upload-time = "2025-10-13T16:12:24.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/56/52fa74294254e1f53a4ff170ee2006e57886cf4bb3db46a02b4f09e1d99f/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c134fa09e7b80a5b7fed626230c5bc257fd771bd6978e754343e7a61d96bc7e6", size = 2451269, upload-time = "2025-10-13T16:12:25.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/51/2e9b34f484cbdd3bac999bf1f48b696d7389433e900639089e8fc4e0da0d/pylibsrtp-1.0.0-cp310-abi3-win32.whl", hash = "sha256:bae377c3b402b17b9bbfbfe2534c2edba17aa13bea4c64ce440caacbe0858b55", size = 1247503, upload-time = "2025-10-13T16:12:27.39Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/70/43db21af194580aba2d9a6d4c7bd8c1a6e887fa52cd810b88f89096ecad2/pylibsrtp-1.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:8d6527c4a78a39a8d397f8862a8b7cdad4701ee866faf9de4ab8c70be61fd34d", size = 1601659, upload-time = "2025-10-13T16:12:29.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ec/6e02b2561d056ea5b33046e3cad21238e6a9097b97d6ccc0fbe52b50c858/pylibsrtp-1.0.0-cp310-abi3-win_arm64.whl", hash = "sha256:2696bdb2180d53ac55d0eb7b58048a2aa30cd4836dd2ca683669889137a94d2a", size = 1159246, upload-time = "2025-10-13T16:12:30.285Z" },
+]
+
+[[package]]
 name = "pylitterbot"
 source = { editable = "." }
 dependencies = [
@@ -1121,6 +1296,11 @@ dependencies = [
     { name = "deepdiff" },
     { name = "pycognito" },
     { name = "pyjwt" },
+]
+
+[package.optional-dependencies]
+camera = [
+    { name = "aiortc" },
 ]
 
 [package.dev-dependencies]
@@ -1141,10 +1321,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.8.1" },
+    { name = "aiortc", marker = "extra == 'camera'", specifier = ">=1.9.0" },
     { name = "deepdiff", specifier = ">=6.2.1" },
     { name = "pycognito", specifier = ">=2024.2.0" },
     { name = "pyjwt", specifier = ">=2.7.0" },
 ]
+provides-extras = ["camera"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1159,6 +1341,19 @@ dev = [
     { name = "ruff", specifier = "==0.15.10" },
     { name = "tox", specifier = "==4.52.1" },
     { name = "tox-uv", specifier = ">=1.25.0" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Second PR in the LR5 series (follows #363). Adds camera support for Litter-Robot 5 Pro:

- **CameraClient** — REST API client for camera sessions, video clips, settings, and events
- **CameraSession** / **VideoClip** — dataclasses with confirmed API field names
- **CameraSignalingRelay** — browser-based WebRTC signaling relay
- **CameraStream** — server-side WebRTC streaming via aiortc (optional dependency)
- **LR5 convenience methods** — `has_camera`, `get_camera_client`, `get_camera_session`, `get_camera_videos`, `get_camera_video_settings`, `set_camera_view`, `create_camera_stream`
- **set_camera_audio** — updated to use camera settings API (robot API's `soundSettings.cameraAudioEnabled` doesn't reflect changes made via camera API)

### Feedback from #356 applied upfront

- Removed speculative `duration` field from `VideoClip` — API only returns `hlsDuration`
- Base URLs with `device_id` baked into `CameraClient.__init__` (`_settings_base`, `_inventory_base`)
- `signalingURL` read from generate-session API response instead of hardcoded
- Specific return types on all LR5 methods (no `Any`)
- No section divider comments, no version bumps
- All field names verified against live LR5 Pro API responses

### API field notes

- Video list API does not enforce `limit` query parameter server-side
- `turnServer` is returned as a dict (not list), with keys: `username`, `password`, `stunUrl`, `turnUrl`
- `createdAt` on video clips is a float epoch timestamp (handled by `to_timestamp` from #363)

## Test plan

- [x] `ruff check` + `ruff format` — clean
- [x] `mypy` — no issues
- [x] `pytest` — 422 passed
- [x] Live tested against LR5 Pro: session generation, TURN credentials, video clips, video settings, camera view switching (front/globe), camera audio toggle, error handling for non-camera robots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LR5 Pro camera support: session generation, recorded video/event retrieval, optional WebRTC live streaming, and camera controls (view, audio, video) surfaced on LitterRobot5.
* **Bug Fixes**
  * More robust signaling and SDP handling, ICE candidate buffering/delivery, and safer handling of unexpected REST responses.
* **Tests**
  * Added comprehensive camera unit and integration tests and updated LR5 camera-audio tests.
* **Chores**
  * Added optional WebRTC extra (aiortc).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->