### PR TITLE
Allow robot retrieval to be filtered by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,21 @@ which will output something like:
 Name: Litter-Robot Name, Serial: LR3C012345, id: a0123b4567cd8e
 ```
 
+If you only want to discover specific robot families, pass the classes you want
+to query when you create the account or when you load robots:
+
+```python
+from pylitterbot import Account, LitterRobot4, LitterRobot5
+
+account = Account(robot_types=[LitterRobot4, LitterRobot5])
+
+await account.connect(
+  username=username,
+  password=password,
+  load_robots=True,
+)
+```
+
 To start a clean cycle
 
 ```python

--- a/pylitterbot/account.py
+++ b/pylitterbot/account.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TypeVar, cast
 
 from aiohttp import (
@@ -29,6 +29,12 @@ from .utils import decode, urljoin
 
 _LOGGER = logging.getLogger(__name__)
 _RobotT = TypeVar("_RobotT", bound=Robot)
+DEFAULT_ROBOT_TYPES: tuple[type[Robot], ...] = (
+    LitterRobot3,
+    LitterRobot4,
+    LitterRobot5,
+    FeederRobot,
+)
 
 
 class Account:
@@ -39,6 +45,7 @@ class Account:
         token: dict | None = None,
         websession: ClientSession | None = None,
         token_update_callback: Callable[[dict | None], None] | None = None,
+        robot_types: Iterable[type[Robot]] | None = None,
     ) -> None:
         """Initialize the account data."""
         self._session = LitterRobotSession(token=token, websession=websession)
@@ -49,6 +56,9 @@ class Account:
         self._user: dict = {}
         self._robots: list[Robot] = []
         self._pets: list[Pet] = []
+        self._robot_types = (
+            tuple(robot_types) if robot_types is not None else DEFAULT_ROBOT_TYPES
+        )
         self._monitors: dict[type[Robot], WebSocketMonitor] = {}
 
         if token_update_callback:
@@ -111,6 +121,7 @@ class Account:
         load_robots: bool = False,
         subscribe_for_updates: bool = False,
         load_pets: bool = False,
+        robot_types: Iterable[type[Robot]] | None = None,
     ) -> None:
         """Connect to the Litter-Robot API."""
         try:
@@ -125,7 +136,10 @@ class Account:
                     )
 
             if load_robots:
-                await self.load_robots(subscribe_for_updates)
+                await self.load_robots(
+                    subscribe_for_updates=subscribe_for_updates,
+                    robot_types=robot_types,
+                )
 
             if load_pets:
                 await self.load_pets()
@@ -177,18 +191,22 @@ class Account:
                 else:
                     self._pets.append(pet)
 
-    async def load_robots(self, subscribe_for_updates: bool = False) -> None:
+    async def load_robots(
+        self,
+        subscribe_for_updates: bool = False,
+        robot_types: Iterable[type[Robot]] | None = None,
+    ) -> None:
         """Get information about robots connected to the account."""
         robots: list[Robot] = []
-        robot_types: list[type[Robot]] = [
-            LitterRobot3,
-            LitterRobot4,
-            LitterRobot5,
-            FeederRobot,
-        ]
+        robot_types_to_load = (
+            tuple(robot_types) if robot_types is not None else self._robot_types
+        )
         try:
             resp = await asyncio.gather(
-                *(robot_cls.fetch_for_account(self) for robot_cls in robot_types),
+                *(
+                    robot_cls.fetch_for_account(self)
+                    for robot_cls in robot_types_to_load
+                ),
                 return_exceptions=True,
             )
 
@@ -211,7 +229,7 @@ class Account:
                         await robot.subscribe()
                 robots.append(robot)
 
-            for robot_cls, result in zip(robot_types, resp):
+            for robot_cls, result in zip(robot_types_to_load, resp):
                 if isinstance(result, BaseException):
                     _LOGGER.error("Failed to fetch %s: %s", robot_cls.__name__, result)
                     # Preserve previously-known robots of this type rather than dropping them

--- a/tests/common.py
+++ b/tests/common.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 from aiohttp import ClientConnectorError, ClientResponseError, ClientWebSocketResponse
 
-from pylitterbot import Account, LitterRobot, Pet
+from pylitterbot import Account, LitterRobot, Pet, Robot
 from pylitterbot.robot.litterrobot3 import DEFAULT_ENDPOINT
 
 USERNAME = "username@username.com"
@@ -486,6 +486,7 @@ async def get_account(
     load_robots: bool = False,
     load_pets: bool = False,
     token_update_callback: Callable[[dict | None], None] | None = None,
+    robot_types: list[type[Robot]] | None = None,
 ) -> Account:
     """Get an account that has the underlying API patched."""
     with patch(
@@ -494,7 +495,10 @@ async def get_account(
             Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock(), Mock()
         ),
     ):
-        account = Account(token_update_callback=token_update_callback)
+        account = Account(
+            token_update_callback=token_update_callback,
+            robot_types=robot_types,
+        )
         if logged_in:
             await account.connect(
                 username=USERNAME,

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -102,6 +102,29 @@ async def test_account_get_robots(mock_aioresponse: aioresponses) -> None:
     await account.disconnect()
 
 
+async def test_account_robot_type_filter(mock_aioresponse: aioresponses) -> None:
+    """Tests that robot discovery can be limited to specific robot classes."""
+    account = await get_account(
+        token_update_callback=lambda token: None,
+        robot_types=[LitterRobot4, LitterRobot5],
+    )
+
+    await account.connect(username=USERNAME, password=PASSWORD, load_robots=True)
+
+    assert len(account.robots) == 3
+    assert len(account.get_robots(LitterRobot3)) == 0
+    assert len(account.get_robots(LitterRobot4)) == 1
+    assert len(account.get_robots(LitterRobot5)) == 2
+    assert len(account.get_robots(FeederRobot)) == 0
+
+    await account.load_robots(robot_types=[FeederRobot])
+
+    assert len(account.robots) == 1
+    assert len(account.get_robots(FeederRobot)) == 1
+
+    await account.disconnect()
+
+
 # @pytest.mark.parametrize(
 #     "side_effect,exception",
 #     [


### PR DESCRIPTION
Hi!

I was seeing the following error:

```
Failed to fetch LitterRobot3: 403, message='Forbidden', url='https://v2.api.whisker.iothings.site/users/1403312/robots'
Robots:
Name: Poopbot, Model: Litter-Robot 4, Serial: xxx, id: xxx
```

So it looks like the LR3 endpoint is bad for me. But - I only have an LR4, and that still seems to work.

This PR adds the ability to only query endpoints I'm interested in - so I can do this:

```python
from pylitterbot import Account, LitterRobot4

account = Account(robot_types=[LitterRobot4])

await account.connect(
  username=username,
  password=password,
  load_robots=True,
)
```

Which might save a few HTTP requests here and there too. 

No obligation to merge this, even if it's just used as inspiration, love the package, thanks for what you do!

Test coverage maintained at 91%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `robot_types` parameter to Account initialization and the connect method, enabling users to restrict robot discovery and loading to specific robot families instead of discovering all robots.

* **Documentation**
  * Updated README with a new usage example demonstrating how to filter robot discovery to selected robot families.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->