### PR TITLE
Deprecate power_status and add power_type and is_on properties

### DIFF
--- a/pylitterbot/robot/__init__.py
+++ b/pylitterbot/robot/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from abc import abstractmethod
 from collections.abc import Callable
 from datetime import datetime
@@ -13,6 +14,11 @@ from deepdiff import DeepDiff
 from ..event import EVENT_UPDATE, Event
 from ..transport import Transport
 from ..utils import to_timestamp, urljoin
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
 
 if TYPE_CHECKING:
     from ..account import Account
@@ -35,10 +41,10 @@ class Robot(Event):
     _transport: Transport | None = None
     _subscribed: bool = False
 
-    def __init__(self, data: dict, account: Account) -> None:
+    def __init__(self, data: dict[str, Any], account: Account) -> None:
         """Initialize a robot."""
         super().__init__()
-        self._data: dict = {}
+        self._data: dict[str, Any] = {}
         self._account = account
 
         self._is_loaded = False
@@ -68,6 +74,11 @@ class Robot(Event):
 
     @property
     @abstractmethod
+    def is_on(self) -> bool:
+        """Return `True` if the robot is on."""
+
+    @property
+    @abstractmethod
     def is_online(self) -> bool:
         """Return `True` if the robot is online."""
 
@@ -93,6 +104,7 @@ class Robot(Event):
 
     @property
     @abstractmethod
+    @deprecated("power_status is deprecated")
     def power_status(self) -> str:
         """Return the power type.
 

--- a/pylitterbot/robot/feederrobot.py
+++ b/pylitterbot/robot/feederrobot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from copy import deepcopy
 from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, TypeVar, cast
@@ -17,6 +18,11 @@ from ..transport import WebSocketMonitor, WebSocketProtocol
 from ..utils import decode, to_timestamp, utcnow
 from . import Robot
 from .models import FEEDER_ROBOT_MODEL
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
 
 if TYPE_CHECKING:
     from ..account import Account
@@ -90,6 +96,11 @@ class FeederRobot(Robot):  # pylint: disable=abstract-method
         return bool(self._state_info("gravity"))
 
     @property
+    def is_on(self) -> bool:
+        """Return `True` if the robot is on."""
+        return self._state_info("power")
+
+    @property
     def is_onboarded(self) -> bool:
         """Return `True` if the robot is onboarded."""
         return bool(self._state_info("onBoarded"))
@@ -157,7 +168,18 @@ class FeederRobot(Robot):  # pylint: disable=abstract-method
         return bool(self._state_info("panelLockout"))
 
     @property
+    @deprecated("Use power_type instead")
     def power_status(self) -> str:
+        """Return the power type.
+
+        `AC` = normal/mains
+        `DC` = battery backup
+        `NC` = unknown, not connected or off
+        """
+        return self.power_type
+
+    @property
+    def power_type(self) -> str:
         """Return the power type.
 
         `AC` = normal/mains

--- a/pylitterbot/robot/feederrobot.py
+++ b/pylitterbot/robot/feederrobot.py
@@ -98,7 +98,7 @@ class FeederRobot(Robot):  # pylint: disable=abstract-method
     @property
     def is_on(self) -> bool:
         """Return `True` if the robot is on."""
-        return self._state_info("power")
+        return bool(self._state_info("power"))
 
     @property
     def is_onboarded(self) -> bool:

--- a/pylitterbot/robot/litterrobot.py
+++ b/pylitterbot/robot/litterrobot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from abc import abstractmethod
 from collections.abc import Callable
 from datetime import datetime, time
@@ -14,6 +15,11 @@ from ..enums import LitterBoxCommand, LitterBoxStatus
 from ..sleep_schedule import SleepSchedule
 from ..utils import to_timestamp
 from . import Robot
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,8 +102,9 @@ class LitterRobot(Robot):
         return to_timestamp(self._data.get("lastSeen"))
 
     @property
+    @deprecated("Use power_type instead")
     def power_status(self) -> str:
-        """Return the power status.
+        """Return the power type.
 
         `AC` = normal/mains
         `DC` = battery backup

--- a/pylitterbot/robot/litterrobot3.py
+++ b/pylitterbot/robot/litterrobot3.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from datetime import datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -15,6 +16,11 @@ from ..sleep_schedule import SleepSchedule
 from ..transport import WebSocketMonitor, WebSocketProtocol
 from ..utils import to_timestamp, today_at_time, urljoin, utcnow
 from .litterrobot import MINIMUM_CYCLES_LEFT_DEFAULT, LitterRobot
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
 
 if TYPE_CHECKING:
     from ..account import Account
@@ -68,9 +74,14 @@ class LitterRobot3(LitterRobot):
         return bool(self._data.get("isDFITriggered", "0") != "0")
 
     @property
+    def is_on(self) -> bool:
+        """Return `True` if the robot is on."""
+        return self.is_online
+
+    @property
     def is_online(self) -> bool:
         """Return `True` if the robot is online."""
-        return self.power_status != "NC" and self.status != LitterBoxStatus.OFFLINE
+        return self.power_type != "NC" and self.status != LitterBoxStatus.OFFLINE
 
     @property
     def is_sleeping(self) -> bool:
@@ -96,6 +107,27 @@ class LitterRobot3(LitterRobot):
     def panel_lock_enabled(self) -> bool:
         """Return `True` if the buttons on the robot are disabled."""
         return bool(self._data.get("panelLockActive", "0") != "0")
+
+    @property
+    @deprecated("Use power_type instead")
+    def power_status(self) -> str:
+        """Return the power type.
+
+        `AC` = normal/mains
+        `DC` = battery backup
+        `NC` = unknown, not connected or off
+        """
+        return self.power_type
+
+    @property
+    def power_type(self) -> str:
+        """Return the power type.
+
+        `AC` = normal/mains
+        `DC` = battery backup
+        `NC` = unknown, not connected or off
+        """
+        return cast(str, self._data.get("powerStatus", "NC"))
 
     @property
     def sleep_mode_enabled(self) -> bool:

--- a/pylitterbot/robot/litterrobot4.py
+++ b/pylitterbot/robot/litterrobot4.py
@@ -227,7 +227,7 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
     @property
     def is_on(self) -> bool:
         """Return `True` if the robot is on."""
-        return self._data.get("unitPowerStatus") == "ON"
+        return bool(self._data.get("unitPowerStatus", "") == "ON")
 
     @property
     def is_online(self) -> bool:

--- a/pylitterbot/robot/litterrobot4.py
+++ b/pylitterbot/robot/litterrobot4.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from datetime import datetime, timedelta
 from enum import Enum, unique
 from json import dumps
@@ -27,6 +28,11 @@ from ..transport import WebSocketMonitor, WebSocketProtocol
 from ..utils import calculate_litter_level, encode, to_enum, to_timestamp, utcnow
 from .litterrobot import LitterRobot
 from .models import LITTER_ROBOT_4_MODEL
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
 
 if TYPE_CHECKING:
     from ..account import Account
@@ -142,7 +148,6 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
     _data_drawer_full_cycles = "DFIFullCounter"
     _data_id = "unitId"
     _data_name = "name"
-    _data_power_status = "unitPowerType"
     _data_serial = "serial"
     _data_setup_date = "setupDateTime"
 
@@ -218,6 +223,11 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
     def is_hopper_removed(self) -> bool:
         """Return `True` if the hopper is removed/disabled."""
         return self._data.get("isHopperRemoved") is True
+
+    @property
+    def is_on(self) -> bool:
+        """Return `True` if the robot is on."""
+        return self._data.get("unitPowerStatus") == "ON"
 
     @property
     def is_online(self) -> bool:
@@ -302,6 +312,27 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
         return cast(float, self._data.get("catWeight", 0))
 
     @property
+    @deprecated("Use power_type instead")
+    def power_status(self) -> str:
+        """Return the power type.
+
+        `AC` = normal/mains
+        `DC` = battery backup
+        `NC` = unknown, not connected or off
+        """
+        return self.power_type
+
+    @property
+    def power_type(self) -> str:
+        """Return the power type.
+
+        `AC` = normal/mains
+        `DC` = battery backup
+        `NC` = unknown, not connected or off
+        """
+        return cast(str, self._data.get("unitPowerType", "NC"))
+
+    @property
     def scoops_saved_count(self) -> int:
         """Return the scoops saved count."""
         return cast(int, self._data.get("scoopsSavedCount", 0))
@@ -319,6 +350,8 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
         """
         if not self.is_online:
             return LitterBoxStatus.OFFLINE
+        if not self.is_on:
+            return LitterBoxStatus.OFF
         if status := CYCLE_STATE_STATUS_MAP.get(self._data["robotCycleState"]):
             return status
         status = LR4_STATUS_MAP.get(self._data["robotStatus"], LitterBoxStatus.UNKNOWN)

--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from copy import deepcopy
 from datetime import datetime, time
 from typing import TYPE_CHECKING, Any, cast
@@ -24,6 +25,11 @@ from ..sleep_schedule import SleepSchedule
 from ..transport import PollingTransport
 from ..utils import calculate_litter_level, to_enum, to_timestamp, urljoin
 from .litterrobot import LitterRobot
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+    from typing_extensions import deprecated
 
 if TYPE_CHECKING:
     from ..account import Account
@@ -113,7 +119,6 @@ class LitterRobot5(LitterRobot):
     _data_drawer_full_cycles = "DFIFullCounter"
     _data_id = "serial"
     _data_name = "name"
-    _data_power_status = "powerStatus"
     _data_serial = "serial"
     _data_setup_date = "setupDateTime"
 
@@ -323,6 +328,11 @@ class LitterRobot5(LitterRobot):
         return self._state.get("isLaserDirty") is True
 
     @property
+    def is_on(self) -> bool:
+        """Return `True` if the robot is on."""
+        return self._state.get("powerStatus") == "On"
+
+    @property
     def is_online(self) -> bool:
         """Return `True` if the robot is online."""
         return self._state.get("isOnline") is True
@@ -451,9 +461,10 @@ class LitterRobot5(LitterRobot):
         return (self._state.get("weightSensor") or 0.0) / 100
 
     @property
+    @deprecated("Use is_on instead")
     def power_status(self) -> str:
         """Return the power status."""
-        return cast(str, self._state.get(self._data_power_status, "On"))
+        return cast(str, self._state.get("powerStatus", "On"))
 
     @property
     def privacy_mode(self) -> str:

--- a/tests/test_feederrobot.py
+++ b/tests/test_feederrobot.py
@@ -34,24 +34,32 @@ async def test_feeder_robot(
     assert robot.firmware == "1.0.0"
     assert robot.food_level == 10
     assert not robot.gravity_mode_enabled
+    assert robot.is_on
     assert robot.is_online
     assert robot.last_feeding == robot.last_meal
     assert robot.meal_insert_size == 0.125
     assert robot.night_light_mode_enabled
     assert not robot.panel_lock_enabled
     assert robot.power_status == "AC"
+    assert robot.power_type == "AC"
 
     utc = timezone.utc
     assert robot.get_food_dispensed_since(datetime(2022, 8, 1, tzinfo=utc)) == 0.75
     assert robot.get_food_dispensed_since(datetime(2022, 9, 1, tzinfo=utc)) == 0.5
 
     # simulate different power statuses
+    FEEDER_ROBOT_DATA["state"]["info"]["power"] = False
     FEEDER_ROBOT_DATA["state"]["info"]["acPower"] = False
     robot._update_data(FEEDER_ROBOT_DATA)
+    assert not robot.is_on
     assert robot.power_status == "NC"
+    assert robot.power_type == "NC"
+    FEEDER_ROBOT_DATA["state"]["info"]["power"] = True
     FEEDER_ROBOT_DATA["state"]["info"]["dcPower"] = True
     robot._update_data(FEEDER_ROBOT_DATA)
+    assert robot.is_on
     assert robot.power_status == "DC"
+    assert robot.power_type == "DC"
 
     mock_aioresponse.clear()
     mock_aioresponse.post(

--- a/tests/test_feederrobot.py
+++ b/tests/test_feederrobot.py
@@ -40,7 +40,8 @@ async def test_feeder_robot(
     assert robot.meal_insert_size == 0.125
     assert robot.night_light_mode_enabled
     assert not robot.panel_lock_enabled
-    assert robot.power_status == "AC"
+    with pytest.warns(DeprecationWarning, match="power_type"):
+        assert robot.power_status == "AC"
     assert robot.power_type == "AC"
 
     utc = timezone.utc
@@ -52,13 +53,15 @@ async def test_feeder_robot(
     FEEDER_ROBOT_DATA["state"]["info"]["acPower"] = False
     robot._update_data(FEEDER_ROBOT_DATA)
     assert not robot.is_on
-    assert robot.power_status == "NC"
+    with pytest.warns(DeprecationWarning, match="power_type"):  # type: ignore[unreachable]
+        assert robot.power_status == "NC"
     assert robot.power_type == "NC"
     FEEDER_ROBOT_DATA["state"]["info"]["power"] = True
     FEEDER_ROBOT_DATA["state"]["info"]["dcPower"] = True
     robot._update_data(FEEDER_ROBOT_DATA)
     assert robot.is_on
-    assert robot.power_status == "DC"
+    with pytest.warns(DeprecationWarning, match="power_type"):
+        assert robot.power_status == "DC"
     assert robot.power_type == "DC"
 
     mock_aioresponse.clear()
@@ -107,7 +110,7 @@ async def test_feeder_robot(
     assert await robot.give_snack()
     assert await robot.set_gravity_mode(True)
     assert robot.gravity_mode_enabled
-    assert robot.next_feeding is None  # type: ignore[unreachable]
+    assert robot.next_feeding is None
     assert await robot.set_night_light(True)
     assert await robot.set_panel_lockout(True)
 

--- a/tests/test_litterrobot3.py
+++ b/tests/test_litterrobot3.py
@@ -58,6 +58,7 @@ async def test_litter_robot_3_setup(
     assert robot.cycle_count == 15
     assert robot.cycles_after_drawer_full == 0
     assert not robot.is_drawer_full_indicator_triggered
+    assert robot.is_on
     assert robot.is_onboarded
     assert robot.is_online
     assert robot.is_sleeping
@@ -70,6 +71,7 @@ async def test_litter_robot_3_setup(
     assert robot.night_light_mode_enabled
     assert not robot.panel_lock_enabled
     assert robot.power_status == "AC"
+    assert robot.power_type == "AC"
     assert robot.setup_date == datetime(year=2021, month=1, day=1, tzinfo=timezone.utc)
     assert robot.sleep_mode_enabled
     assert robot.sleep_mode_start_time and robot.sleep_mode_start_time.timetz() == time(

--- a/tests/test_litterrobot3.py
+++ b/tests/test_litterrobot3.py
@@ -70,7 +70,8 @@ async def test_litter_robot_3_setup(
     assert robot.name == ROBOT_NAME
     assert robot.night_light_mode_enabled
     assert not robot.panel_lock_enabled
-    assert robot.power_status == "AC"
+    with pytest.warns(DeprecationWarning, match="power_type"):
+        assert robot.power_status == "AC"
     assert robot.power_type == "AC"
     assert robot.setup_date == datetime(year=2021, month=1, day=1, tzinfo=timezone.utc)
     assert robot.sleep_mode_enabled

--- a/tests/test_litterrobot4.py
+++ b/tests/test_litterrobot4.py
@@ -54,6 +54,7 @@ async def test_litter_robot_4(
     assert not robot.is_drawer_full_indicator_triggered
     assert robot.globe_motor_fault_status == GlobeMotorFaultStatus.FAULT_CLEAR
     assert robot.globe_motor_retract_fault_status == GlobeMotorFaultStatus.FAULT_CLEAR
+    assert robot.is_on
     assert robot.is_onboarded
     assert robot.is_online
     assert not robot.is_sleeping
@@ -71,6 +72,7 @@ async def test_litter_robot_4(
     assert not robot.panel_lock_enabled
     assert robot.pet_weight == 7.93
     assert robot.power_status == "AC"
+    assert robot.power_type == "AC"
     assert robot.setup_date == datetime(
         year=2022, month=7, day=16, hour=21, minute=40, tzinfo=timezone.utc
     )
@@ -539,6 +541,10 @@ async def test_litter_hopper_toggle(
                 "robotCycleState": "CYCLE_STATE_CAT_DETECT",
             },
             LitterBoxStatus.CAT_SENSOR_INTERRUPTED,
+        ),
+        (
+            {"robotCycleState": "CYCLE_STATE_PAUSE", "unitPowerStatus": "OFF"},
+            LitterBoxStatus.OFF,
         ),
     ],
 )

--- a/tests/test_litterrobot4.py
+++ b/tests/test_litterrobot4.py
@@ -71,7 +71,8 @@ async def test_litter_robot_4(
     assert robot.panel_brightness == BrightnessLevel.HIGH
     assert not robot.panel_lock_enabled
     assert robot.pet_weight == 7.93
-    assert robot.power_status == "AC"
+    with pytest.warns(DeprecationWarning, match="power_type"):
+        assert robot.power_status == "AC"
     assert robot.power_type == "AC"
     assert robot.setup_date == datetime(
         year=2022, month=7, day=16, hour=21, minute=40, tzinfo=timezone.utc
@@ -231,7 +232,7 @@ async def test_litter_robot_4(
     await robot.refresh()
     assert robot.night_light_brightness == 10
     assert robot.night_light_level is None
-    assert robot.night_light_mode is None  # type: ignore
+    assert robot.night_light_mode is None  # type: ignore[unreachable]
     assert robot.panel_brightness is None
     assert robot.status == LitterBoxStatus.DRAWER_FULL
 

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -51,6 +51,7 @@ async def test_litter_robot_5(
     assert robot.hopper_status == HopperStatus.DISABLED  # case-insensitive match
     assert not robot.is_drawer_full_indicator_triggered
     assert robot.is_hopper_removed is True
+    assert robot.is_on
     assert robot.is_online
     assert not robot.is_sleeping
     assert not robot.is_smart_weight_enabled

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -68,7 +68,8 @@ async def test_litter_robot_5(
     assert robot.panel_brightness == BrightnessLevel.LOW  # from displayIntensity
     assert not robot.panel_lock_enabled
     assert robot.pet_weight == 11.04
-    assert robot.power_status == "On"
+    with pytest.warns(DeprecationWarning, match="is_on"):
+        assert robot.power_status == "On"
     assert robot.scoops_saved_count == 80
     assert not robot.sleep_mode_enabled
     assert robot.sleep_mode_start_time is None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added is_on property to all robot models to indicate powered state.
  * Added power_type property for consistent power classification across devices.

* **Deprecations**
  * power_status is deprecated; use power_type or is_on instead (access emits deprecation warnings).

* **Improvements**
  * Tightened typing for robot data handling and improved decorator compatibility across Python versions.

* **Tests**
  * Unit tests updated to assert is_on and power_type and to expect deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->