### PR TITLE
Switch LR4 WebSocket to ByUser subscription

### DIFF
--- a/pylitterbot/robot/litterrobot4.py
+++ b/pylitterbot/robot/litterrobot4.py
@@ -765,9 +765,9 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
     def parse_websocket_message(data: dict) -> list[dict] | None:
         """Parse a websocket message."""
         if (data_type := data["type"]) == "data":
-            states = data["payload"]["data"][
-                "litterRobot4StateSubscriptionByUser"
-            ]["robots"]
+            states = data["payload"]["data"]["litterRobot4StateSubscriptionByUser"][
+                "robots"
+            ]
             return states if isinstance(states, list) else None
         if data_type == "error":
             _LOGGER.error(data)

--- a/pylitterbot/robot/litterrobot4.py
+++ b/pylitterbot/robot/litterrobot4.py
@@ -762,11 +762,11 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
         return is_success
 
     @staticmethod
-    def parse_websocket_message(data: dict) -> dict | None:
-        """Parse a wesocket message."""
+    def parse_websocket_message(data: dict) -> list[dict] | None:
+        """Parse a websocket message."""
         if (data_type := data["type"]) == "data":
-            data = data["payload"]["data"]["litterRobot4StateSubscriptionBySerial"]
-            return data
+            states = data["payload"]["data"]["litterRobot4StateSubscriptionByUser"]
+            return states if isinstance(states, list) else None
         if data_type == "error":
             _LOGGER.error(data)
         elif data_type not in ("start_ack", "ka", "complete"):
@@ -824,11 +824,11 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
                     "data": dumps(
                         {
                             "query": f"""
-                                subscription GetLR4($serial: String!) {{
-                                    litterRobot4StateSubscriptionBySerial(serial: $serial) {LITTER_ROBOT_4_MODEL}
+                                subscription GetLR4ByUser($userId: String!) {{
+                                    litterRobot4StateSubscriptionByUser(userId: $userId) {LITTER_ROBOT_4_MODEL}
                                 }}
                             """,
-                            "variables": {"serial": self.serial},
+                            "variables": {"userId": self._account.user_id},
                         }
                     ),
                     "extensions": {
@@ -851,14 +851,18 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
     def _ws_message_handler(self, data: dict) -> None:
         """Handle a message from the WebSocket."""
         parsed = self.parse_websocket_message(data)
-        if isinstance(parsed, dict) and str(parsed.get(self._data_id)) == self.id:
-            self._update_data(parsed)
+        if isinstance(parsed, list):
+            for item in parsed:
+                if isinstance(item, dict) and str(item.get(self._data_id)) == self.id:
+                    self._update_data(item)
+                    break
 
     _WS_PROTOCOL: ClassVar[WebSocketProtocol] = WebSocketProtocol(
         ws_config_factory=_ws_config_factory,
         subscribe_factory=_ws_subscribe,
         unsubscribe_factory=_ws_unsubscribe,
         message_handler=_ws_message_handler,
+        is_shared=True,
     )
 
     def _build_transport(self) -> WebSocketMonitor:

--- a/pylitterbot/robot/litterrobot4.py
+++ b/pylitterbot/robot/litterrobot4.py
@@ -765,7 +765,9 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
     def parse_websocket_message(data: dict) -> list[dict] | None:
         """Parse a websocket message."""
         if (data_type := data["type"]) == "data":
-            states = data["payload"]["data"]["litterRobot4StateSubscriptionByUser"]
+            states = data["payload"]["data"][
+                "litterRobot4StateSubscriptionByUser"
+            ]["robots"]
             return states if isinstance(states, list) else None
         if data_type == "error":
             _LOGGER.error(data)
@@ -825,7 +827,9 @@ class LitterRobot4(LitterRobot):  # pylint: disable=abstract-method
                         {
                             "query": f"""
                                 subscription GetLR4ByUser($userId: String!) {{
-                                    litterRobot4StateSubscriptionByUser(userId: $userId) {LITTER_ROBOT_4_MODEL}
+                                    litterRobot4StateSubscriptionByUser(userId: $userId) {{
+                                        robots {LITTER_ROBOT_4_MODEL}
+                                    }}
                                 }}
                             """,
                             "variables": {"userId": self._account.user_id},

--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -47,6 +47,7 @@ class WebSocketProtocol(Generic[_RobotT]):
         Callable[[_RobotT, ClientWebSocketResponse], Awaitable[None]] | None
     ) = None
     message_handler: Callable[[_RobotT, dict], None] | None = None
+    is_shared: bool = False
 
 
 class Transport(ABC):
@@ -100,7 +101,11 @@ class WebSocketMonitor(Transport):
                 # winding down.  Clear it so _run() reconnects once _connect()
                 # returns, rather than exiting and leaving this listener orphaned.
                 self._stop_event.clear()
-            elif self._ws is not None and self._protocol.subscribe_factory:
+            elif (
+                self._ws is not None
+                and self._protocol.subscribe_factory
+                and not self._protocol.is_shared
+            ):
                 await self._protocol.subscribe_factory(robot, self._ws)
 
     async def stop(self, robot: Robot) -> None:
@@ -110,7 +115,11 @@ class WebSocketMonitor(Transport):
         async with self._lock:
             self._listeners.pop(robot.id, None)
 
-            if self._ws is not None and self._protocol.unsubscribe_factory:
+            if (
+                self._ws is not None
+                and self._protocol.unsubscribe_factory
+                and (not self._protocol.is_shared or not self._listeners)
+            ):
                 try:
                     await self._protocol.unsubscribe_factory(robot, self._ws)
                 except Exception:
@@ -178,8 +187,12 @@ class WebSocketMonitor(Transport):
                     await ws.send_json(connection_init)
 
                 if self._protocol.subscribe_factory:
-                    for robot in list(self._listeners.values()):
-                        await self._protocol.subscribe_factory(robot, ws)
+                    if self._protocol.is_shared:
+                        first_robot = next(iter(self._listeners.values()))
+                        await self._protocol.subscribe_factory(first_robot, ws)
+                    else:
+                        for robot in list(self._listeners.values()):
+                            await self._protocol.subscribe_factory(robot, ws)
 
                 async for msg in ws:
                     if self._stop_event.is_set():

--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -85,6 +85,7 @@ class WebSocketMonitor(Transport):
         self._task: asyncio.Task | None = None
         self._stop_event = asyncio.Event()
         self._ws: ClientWebSocketResponse | None = None
+        self._shared_subscriber: Robot | None = None
 
         self._lock = asyncio.Lock()
 
@@ -121,7 +122,13 @@ class WebSocketMonitor(Transport):
                 and (not self._protocol.is_shared or not self._listeners)
             ):
                 try:
-                    await self._protocol.unsubscribe_factory(robot, self._ws)
+                    unsubscribe_robot = (
+                        self._shared_subscriber if self._protocol.is_shared else robot
+                    )
+                    if unsubscribe_robot is not None:
+                        await self._protocol.unsubscribe_factory(
+                            unsubscribe_robot, self._ws
+                        )
                 except Exception:
                     _LOGGER.debug(
                         "Error sending unsubscribe for %r", robot, exc_info=True
@@ -188,8 +195,8 @@ class WebSocketMonitor(Transport):
 
                 if self._protocol.subscribe_factory:
                     if self._protocol.is_shared:
-                        first_robot = next(iter(self._listeners.values()))
-                        await self._protocol.subscribe_factory(first_robot, ws)
+                        self._shared_subscriber = robot
+                        await self._protocol.subscribe_factory(robot, ws)
                     else:
                         for robot in list(self._listeners.values()):
                             await self._protocol.subscribe_factory(robot, ws)
@@ -212,6 +219,7 @@ class WebSocketMonitor(Transport):
                         break
             finally:
                 self._ws = None
+                self._shared_subscriber = None
 
 
 class PollingTransport(Transport):

--- a/tests/test_litterrobot4.py
+++ b/tests/test_litterrobot4.py
@@ -349,7 +349,9 @@ async def test_litter_robot_4_websocket_subscription_payload() -> None:
     states = [{**LITTER_ROBOT_4_DATA, "DFILevelPercent": 50}]
     message = {
         "type": "data",
-        "payload": {"data": {"litterRobot4StateSubscriptionByUser": states}},
+        "payload": {
+            "data": {"litterRobot4StateSubscriptionByUser": {"robots": states}}
+        },
     }
     assert LitterRobot4.parse_websocket_message(message) == states
     assert LitterRobot4._WS_PROTOCOL.is_shared
@@ -367,10 +369,12 @@ async def test_litter_robot_4_shared_subscription_dispatch(
         "type": "data",
         "payload": {
             "data": {
-                "litterRobot4StateSubscriptionByUser": [
-                    {**data_a, "DFILevelPercent": 42},
-                    {**data_b, "DFILevelPercent": 99},
-                ]
+                "litterRobot4StateSubscriptionByUser": {
+                    "robots": [
+                        {**data_a, "DFILevelPercent": 42},
+                        {**data_b, "DFILevelPercent": 99},
+                    ]
+                }
             }
         },
     }

--- a/tests/test_litterrobot4.py
+++ b/tests/test_litterrobot4.py
@@ -344,6 +344,42 @@ async def test_litter_robot_4(
     await robot._account.disconnect()
 
 
+async def test_litter_robot_4_websocket_subscription_payload() -> None:
+    """LR4 WebSocket data frames use litterRobot4StateSubscriptionByUser."""
+    states = [{**LITTER_ROBOT_4_DATA, "DFILevelPercent": 50}]
+    message = {
+        "type": "data",
+        "payload": {"data": {"litterRobot4StateSubscriptionByUser": states}},
+    }
+    assert LitterRobot4.parse_websocket_message(message) == states
+    assert LitterRobot4._WS_PROTOCOL.is_shared
+
+
+async def test_litter_robot_4_shared_subscription_dispatch(
+    mock_account: Account,
+) -> None:
+    """A ByUser array payload updates each LR4 listener with its own entry."""
+    data_a = {**LITTER_ROBOT_4_DATA, "unitId": "LR4ID-A"}
+    data_b = {**LITTER_ROBOT_4_DATA, "unitId": "LR4ID-B"}
+    robot_a = LitterRobot4(data=data_a, account=mock_account)
+    robot_b = LitterRobot4(data=data_b, account=mock_account)
+    message = {
+        "type": "data",
+        "payload": {
+            "data": {
+                "litterRobot4StateSubscriptionByUser": [
+                    {**data_a, "DFILevelPercent": 42},
+                    {**data_b, "DFILevelPercent": 99},
+                ]
+            }
+        },
+    }
+    robot_a._ws_message_handler(message)
+    robot_b._ws_message_handler(message)
+    assert robot_a.waste_drawer_level == 42
+    assert robot_b.waste_drawer_level == 99
+
+
 async def test_litter_robot_4_sleep_time(
     freezer: FrozenDateTimeFactory, mock_account: Account
 ) -> None:


### PR DESCRIPTION
Replace the deprecated per-serial `litterRobot4StateSubscriptionBySerial` with the shared `litterRobot4StateSubscriptionByUser` stream. A single WebSocket connection now serves all LR4 units on an account, with each robot picking its own entry out of the returned array payload.

Also adds `is_shared` to `WebSocketProtocol` so the transport layer knows to subscribe/unsubscribe once per connection rather than once per robot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Litter-Robot 4 live updates for multi-robot setups by switching to a shared, user-scoped WebSocket subscription and dispatching state from multi-robot payloads only to the matching robot instance.
* **Tests**
  * Added async coverage to verify user-scoped “by user” WebSocket payload parsing, the shared-mode protocol flag, and correct per-robot state updates when multiple entries are received.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->