### PR TITLE
Add Feeder-Robot feeding-schedule write support

### DIFF
--- a/pylitterbot/robot/feederrobot.py
+++ b/pylitterbot/robot/feederrobot.py
@@ -38,6 +38,13 @@ COMMAND_ENDPOINT = (
 COMMAND_ENDPOINT_KEY = decode(
     "dzJ0UEZiamxQMTNHVW1iOGRNalVMNUIyWXlQVkQzcEo3RXk2Zno4dg=="
 )
+# Same API-Gateway stage as COMMAND_ENDPOINT; feeding-schedule CRUD is REST (not GraphQL).
+SCHEDULE_ENDPOINT = (
+    "https://42nk7qrhdg.execute-api.us-east-1.amazonaws.com/prod/feeder/schedule"
+)
+
+# Sentinel value the API uses for a meal that is not skipped.
+NO_SKIP = "0000-01-01T00:00:00.000"
 
 FOOD_LEVEL_MAP = {9: 100, 8: 70, 7: 60, 6: 50, 5: 40, 4: 30, 3: 20, 2: 10, 1: 5, 0: 0}
 MEAL_INSERT_SIZE_CUPS_MAP = {0: 1 / 4, 1: 1 / 8}
@@ -202,6 +209,20 @@ class FeederRobot(Robot):  # pylint: disable=abstract-method
         """Return the updated at string."""
         return str(self._data["state"].get("updated_at"))
 
+    @property
+    def active_schedule(self) -> dict[str, Any] | None:
+        """Return a copy of the active feeding schedule, if any.
+
+        Shape: ``{"id", "name", "created_at", "meals": [...]}`` where each meal
+        is ``{"id", "scheduleId", "mealNumber", "name", "hour", "minute", "days",
+        "portions", "paused", "skip"}``. The result is a deep copy; mutating it
+        does not change the robot's state -- use :meth:`set_schedule` to persist
+        edits.
+        """
+        return deepcopy(
+            cast(dict[str, Any] | None, self._data["state"].get("active_schedule"))
+        )
+
     def get_food_dispensed_since(self, start: datetime) -> float:
         """Return the amount of food (in cups) since the given datetime."""
         feedings: list[dict] = list(self._data.get("feeding_meal") or [])
@@ -235,7 +256,7 @@ class FeederRobot(Robot):  # pylint: disable=abstract-method
 
             # Skip meals with a skip date that is today or in the future
             skip = meal.get("skip")
-            if skip and skip != "0000-01-01T00:00:00.000":
+            if skip and skip != NO_SKIP:
                 skip_dt = datetime.fromisoformat(skip)
                 if skip_dt.tzinfo is None:
                     skip_dt = skip_dt.replace(tzinfo=tz)
@@ -398,6 +419,116 @@ class FeederRobot(Robot):  # pylint: disable=abstract-method
             data["state"]["info"]["panelLockout"] = value
             self._update_data(data)
         return self.panel_lock_enabled == value
+
+    def _active_meals(self) -> list[dict[str, Any]]:
+        """Return the active schedule's meals (already a copy), or raise."""
+        schedule = self.active_schedule
+        if not schedule or not schedule.get("meals"):
+            raise InvalidCommandException(
+                "Feeder-Robot has no active feeding schedule to update."
+            )
+        return cast(list[dict[str, Any]], schedule["meals"])
+
+    @staticmethod
+    def _find_meal(meals: list[dict[str, Any]], meal_number: int) -> dict[str, Any]:
+        """Return the meal with the given ``mealNumber``, or raise."""
+        meal = next((m for m in meals if m.get("mealNumber") == meal_number), None)
+        if meal is None:
+            raise InvalidCommandException(
+                f"No meal with mealNumber {meal_number} in the active schedule."
+            )
+        return meal
+
+    def _next_occurrence(self, meal: dict[str, Any]) -> datetime | None:
+        """Return the next datetime this meal would dispense (ignores skip/paused)."""
+        tz = ZoneInfo(self.timezone)
+        now = datetime.now(tz)
+        meal_time = time(meal["hour"], meal["minute"])
+        best: datetime | None = None
+        for day in meal["days"]:
+            days_ahead = (WEEKDAY_MAP[day] - now.weekday() + 7) % 7
+            if days_ahead == 0 and meal_time <= now.time():
+                days_ahead = 7
+            occurrence = datetime.combine(
+                now.date() + timedelta(days=days_ahead), meal_time
+            ).replace(tzinfo=tz)
+            if best is None or occurrence < best:
+                best = occurrence
+        return best
+
+    async def set_schedule(self, meals: list[dict[str, Any]]) -> bool:
+        """Replace the meals in the active feeding schedule and activate it.
+
+        Each meal dict has the shape returned by :attr:`active_schedule` ->
+        ``meals`` (``mealNumber``, ``hour``, ``minute``, ``days``, ``portions``,
+        ``paused``, ``skip``, ...). Use this for adding/removing/editing meals;
+        :meth:`skip_meal` and :meth:`pause_meal` are convenience wrappers.
+        """
+        schedule = self.active_schedule
+        if not schedule:
+            raise InvalidCommandException(
+                "Feeder-Robot has no active feeding schedule to update."
+            )
+        payload = {
+            "id": schedule.get("id"),
+            "name": schedule.get("name"),
+            "serial": self.serial,
+            "createdAt": schedule.get("created_at"),
+            "meals": meals,
+        }
+        await self._post(
+            SCHEDULE_ENDPOINT,
+            json={"schedule": payload, "setActive": True},
+            headers={"x-api-key": COMMAND_ENDPOINT_KEY},
+        )
+        data = deepcopy(self._data)
+        data["state"]["active_schedule"] = {**schedule, "meals": deepcopy(meals)}
+        data["state"]["updated_at"] = utcnow().isoformat()
+        self._update_data(data)
+        active = self.active_schedule
+        return active is not None and active.get("meals") == meals
+
+    async def skip_meal(self, meal_number: int, skip: bool = True) -> bool:
+        """Skip (or un-skip) the next occurrence of the meal with ``meal_number``.
+
+        Skipping sets the meal's ``skip`` to the date of its next scheduled
+        occurrence at midnight (e.g. ``2026-02-19T00:00:00.000``, matching the
+        app); passing ``skip=False`` clears it.
+        """
+        meals = self._active_meals()
+        meal = self._find_meal(meals, meal_number)
+        if skip:
+            occurrence = self._next_occurrence(meal)
+            meal["skip"] = (
+                occurrence.strftime("%Y-%m-%dT00:00:00.000") if occurrence else NO_SKIP
+            )
+        else:
+            meal["skip"] = NO_SKIP
+        return await self.set_schedule(meals)
+
+    async def pause_meal(self, meal_number: int, paused: bool = True) -> bool:
+        """Pause (or resume) the meal with ``meal_number`` indefinitely."""
+        meals = self._active_meals()
+        self._find_meal(meals, meal_number)["paused"] = paused
+        return await self.set_schedule(meals)
+
+    async def clear_schedule(self) -> bool:
+        """Clear the active feeding schedule (removes all meals)."""
+        await self._post(
+            f"{SCHEDULE_ENDPOINT}/clear",
+            json={"serial": self.serial},
+            headers={"x-api-key": COMMAND_ENDPOINT_KEY},
+        )
+        data = deepcopy(self._data)
+        if data["state"].get("active_schedule"):
+            data["state"]["active_schedule"] = {
+                **data["state"]["active_schedule"],
+                "meals": [],
+            }
+        data["state"]["updated_at"] = utcnow().isoformat()
+        self._update_data(data)
+        active = self.active_schedule
+        return active is None or active.get("meals") == []
 
     @staticmethod
     def parse_websocket_message(data: dict) -> dict | None:

--- a/tests/test_feederrobot.py
+++ b/tests/test_feederrobot.py
@@ -10,7 +10,13 @@ from freezegun.api import FrozenDateTimeFactory
 
 from pylitterbot import Account
 from pylitterbot.exceptions import InvalidCommandException
-from pylitterbot.robot.feederrobot import COMMAND_ENDPOINT, FEEDER_ENDPOINT, FeederRobot
+from pylitterbot.robot.feederrobot import (
+    COMMAND_ENDPOINT,
+    FEEDER_ENDPOINT,
+    NO_SKIP,
+    SCHEDULE_ENDPOINT,
+    FeederRobot,
+)
 from pylitterbot.utils import utcnow
 
 from .common import FEEDER_ROBOT_DATA
@@ -180,3 +186,107 @@ async def test_feeder_robot_schedule(
     data["state"]["updated_at"] = utcnow().isoformat()
     robot._update_data(data)
     assert robot.next_feeding is None
+
+
+async def test_feeder_robot_schedule_writes(
+    freezer: FrozenDateTimeFactory,
+    mock_aioresponse: aioresponses,
+    mock_account: Account,
+) -> None:
+    """Tests that the feeding schedule can be edited, skipped, paused, and cleared."""
+    # Pin the clock so the computed skip date is deterministic. The fixture
+    # timezone is America/Denver and meal 1 ("Breakfast") runs at 06:30 daily,
+    # so the next occurrence of meal 1 from this moment is later the same day.
+    freezer.move_to("2022-07-21 00:00:00-06:00")
+    robot = FeederRobot(data=deepcopy(FEEDER_ROBOT_DATA), account=mock_account)
+    assert robot.active_schedule is not None
+
+    mock_aioresponse.post(SCHEDULE_ENDPOINT, repeat=True)
+    mock_aioresponse.post(f"{SCHEDULE_ENDPOINT}/clear", repeat=True)
+
+    def meal(meal_number: int) -> dict:
+        assert (schedule := robot.active_schedule) is not None
+        return next(m for m in schedule["meals"] if m["mealNumber"] == meal_number)
+
+    def last_request_json(url: str) -> dict:
+        """Return the body of the most recent POST to ``url``.
+
+        Asserts the endpoint was actually called, so a write that silently
+        skipped its HTTP request would fail the test.
+        """
+        for (_method, request_url), calls in mock_aioresponse.requests.items():
+            if str(request_url) == url:
+                body: dict = calls[-1].kwargs["json"]
+                return body
+        raise AssertionError(f"no request was made to {url}")
+
+    # Skip the next occurrence of meal 1 -> its date at midnight, then un-skip.
+    assert await robot.skip_meal(1)
+    assert meal(1)["skip"] == "2022-07-21T00:00:00.000"
+    assert await robot.skip_meal(1, skip=False)
+    assert meal(1)["skip"] == NO_SKIP
+
+    # Pause / resume meal 1.
+    assert await robot.pause_meal(1)
+    assert meal(1)["paused"] is True
+    assert await robot.pause_meal(1, paused=False)
+    assert meal(1)["paused"] is False
+
+    # Edit via set_schedule (e.g. change a meal time).
+    assert (schedule := robot.active_schedule) is not None
+    meals = deepcopy(schedule["meals"])
+    meals[0]["hour"] = 9
+    assert await robot.set_schedule(meals)
+    assert meal(1)["hour"] == 9
+
+    # The outbound payload carries the edit and the activation flag, and
+    # translates the read model's snake_case ``created_at`` to ``createdAt``.
+    sent = last_request_json(SCHEDULE_ENDPOINT)
+    assert sent["setActive"] is True
+    assert sent["schedule"]["serial"] == robot.serial
+    assert sent["schedule"]["createdAt"] == "2021-12-17T07:07:31.047747+00:00"
+    assert "created_at" not in sent["schedule"]
+    assert (
+        next(m for m in sent["schedule"]["meals"] if m["mealNumber"] == 1)["hour"] == 9
+    )
+
+    # Defensive copies: neither the dict returned by ``active_schedule`` nor the
+    # list passed to ``set_schedule`` aliases internal state, so mutating them
+    # afterwards does not silently change the robot without a REST write.
+    snapshot = robot.active_schedule
+    assert snapshot is not None
+    snapshot["meals"][0]["hour"] = 3
+    assert meal(1)["hour"] == 9
+
+    edited = deepcopy(snapshot["meals"])
+    edited[0]["hour"] = 7
+    assert await robot.set_schedule(edited)
+    assert meal(1)["hour"] == 7
+    edited[0]["hour"] = 11  # mutate the caller's list after the write
+    assert meal(1)["hour"] == 7
+
+    # Unknown meal number raises for both skip and pause.
+    with pytest.raises(InvalidCommandException):
+        await robot.skip_meal(99)
+    with pytest.raises(InvalidCommandException):
+        await robot.pause_meal(99)
+
+    # Clear the schedule.
+    assert await robot.clear_schedule()
+    assert (schedule := robot.active_schedule) is not None
+    assert schedule["meals"] == []
+    assert last_request_json(f"{SCHEDULE_ENDPOINT}/clear") == {"serial": robot.serial}
+
+    # No active schedule -> meal writes raise, clear is still a no-op success.
+    data = deepcopy(FEEDER_ROBOT_DATA)
+    data["state"]["active_schedule"] = None
+    robot._update_data(data)
+    with pytest.raises(InvalidCommandException):
+        await robot.skip_meal(1)
+    with pytest.raises(InvalidCommandException):
+        await robot.pause_meal(1)
+    with pytest.raises(InvalidCommandException):
+        await robot.set_schedule([])
+    assert await robot.clear_schedule()
+
+    await robot._account.disconnect()


### PR DESCRIPTION
## Summary

The library currently exposes the Feeder-Robot feeding schedule **read-only** — only `next_feeding` is derived from `active_schedule`. This adds write support so the schedule can be edited, skipped, paused, and cleared.

- Add `active_schedule` property — the active schedule (`{"id", "name", "created_at", "meals": [...]}`)
- Add `set_schedule(meals)` — replace the schedule's meals (add/remove/edit)
- Add `skip_meal(meal_number, skip=True)` — skip/un-skip the next occurrence of a meal
- Add `pause_meal(meal_number, paused=True)` — pause/resume a meal indefinitely
- Add `clear_schedule()` — clear the active schedule
- Reflect writes in local state immediately (mirrors `set_gravity_mode` et al.), which also refreshes `next_feeding`
- Add tests for all new methods

`skip_meal` and `pause_meal` are thin convenience wrappers over `set_schedule`.

### API

Schedule writes are REST `POST`s against the same API-Gateway stage already used for feeder commands (`COMMAND_ENDPOINT`), reusing the existing Bearer + `x-api-key` auth. Reads stay on the existing Hasura GraphQL endpoint.

| Method | Request |
|--------|---------|
| `set_schedule` / `skip_meal` / `pause_meal` | `POST /feeder/schedule` with `{"schedule": {...}, "setActive": true}` |
| `clear_schedule` | `POST /feeder/schedule/clear` with `{"serial": ...}` |

These endpoints and payload shapes were reverse-engineered from app traffic and can't be validated against a published API spec — happy to adjust naming/shape with better insight into the contract.

## Example

```python
feeder = ...  # a FeederRobot

await feeder.skip_meal(1)                 # skip the next occurrence of meal 1
await feeder.pause_meal(2)                # pause meal 2 indefinitely
await feeder.pause_meal(2, paused=False)  # resume it

meals = feeder.active_schedule["meals"]   # move breakfast to 09:00
meals[0]["hour"] = 9
await feeder.set_schedule(meals)

await feeder.clear_schedule()             # remove all scheduled meals
```

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy pylitterbot tests` — no issues
- [x] `pytest` — full suite passes (405 passed)
- [x] Tested against live Feeder-Robot hardware — verified a schedule write (`pause_meal` → `set_schedule` → `POST /feeder/schedule`) round-trips and persists server-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added feeding schedule management via REST support, including set, clear, skip, and pause for individual meals
  - Exposed the current active feeding schedule (`active_schedule`) for viewing

- **Bug Fixes**
  - Updated next-feeding logic to properly interpret the “not skipped” schedule state

- **Tests**
  - Added deterministic tests validating schedule write payloads, state updates, defensive-copy behavior, unknown meal error handling, and safe behavior when no active schedule exists
<!-- end of auto-generated comment: release notes by coderabbit.ai -->