### PR TITLE
Add breed property to pet

### DIFF
--- a/pylitterbot/pet.py
+++ b/pylitterbot/pet.py
@@ -196,6 +196,15 @@ class Pet(Event):
         return self.last_weight_reading or self.estimated_weight
 
     @property
+    def breed(self) -> str:
+        """Return the breed, if known."""
+        if not (breeds := self.breeds):
+            return "Unknown"
+        if len(breeds) > 1:
+            return "Mixed-breed"
+        return breeds[0].replace("_", " ").title()
+
+    @property
     def breeds(self) -> list[str] | None:
         """Return the breeds, if known."""
         return self._data.get("breeds")

--- a/tests/test_pet.py
+++ b/tests/test_pet.py
@@ -30,6 +30,7 @@ async def test_pet_setup(mock_aiointercept: aiointercept) -> None:
     assert pet.estimated_weight == 8.5
     assert pet.last_weight_reading == 8.6
     assert pet.weight == 8.6
+    assert pet.breed == "Sphynx"
     assert pet.breeds == ["sphynx"]
     assert pet.age == 0
     assert pet.birthday == date(2016, 7, 2)
@@ -49,6 +50,31 @@ async def test_pet_setup(mock_aiointercept: aiointercept) -> None:
     )
     assert pet.weight_history[0].weight == 8.68
     assert pet.get_visits_since(datetime(2024, 4, 17, 9, tzinfo=timezone.utc)) == 1
+
+
+@pytest.mark.parametrize(
+    "breeds,breed",
+    [
+        (["sphynx"], "Sphynx"),
+        (["british_shorthair"], "British Shorthair"),
+        (["british_shorthair", "siamese"], "Mixed-breed"),
+        (["british_shorthair", "siamese", "other"], "Mixed-breed"),
+        ([], "Unknown"),
+        (None, "Unknown"),
+    ],
+)
+async def test_pet_breeds(
+    mock_aiointercept: aiointercept,
+    caplog: pytest.LogCaptureFixture,
+    breeds: list[str] | None,
+    breed: str,
+) -> None:
+    """Tests expected pet breed values."""
+    pet = await get_pet()
+
+    pet._data |= {"breeds": breeds}
+    assert pet.breeds == breeds
+    assert pet.breed == breed
 
 
 async def test_pet_with_unexpected_values(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readable breed label for pets, making it easier to display a pet’s breed in a user-friendly format.
  * Supports single breeds, mixed breeds, and cases where breed information is unavailable.

* **Tests**
  * Expanded coverage to verify breed display behavior across common breed data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->