### PR TITLE
Add LR5 night_light_rgb_color and RGB tuple support in set_night_light_settings

### DIFF
--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -34,7 +34,15 @@ from ..exceptions import (
 )
 from ..sleep_schedule import SleepSchedule
 from ..transport import PollingTransport
-from ..utils import calculate_litter_level, decode, to_enum, to_timestamp, urljoin
+from ..utils import (
+    calculate_litter_level,
+    decode,
+    hex_to_rgb,
+    rgb_to_hex,
+    to_enum,
+    to_timestamp,
+    urljoin,
+)
 from .litterrobot import LitterRobot
 
 if sys.version_info >= (3, 13):
@@ -423,6 +431,17 @@ class LitterRobot5(LitterRobot):
         return self._night_light_settings.get("color")
 
     @property
+    def night_light_rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the night light color as an RGB tuple, if valid."""
+        if (color := self.night_light_color) is None:
+            return None
+        try:
+            return hex_to_rgb(color)
+        except ValueError:
+            _LOGGER.warning("Unexpected night light color: %s", color)
+            return None
+
+    @property
     def night_light_level(self) -> BrightnessLevel | None:
         """Return the night light level."""
         brightness = self._night_light_settings.get("brightness")
@@ -731,14 +750,14 @@ class LitterRobot5(LitterRobot):
         *,
         mode: NightLightMode | None = None,
         brightness: int | None = None,
-        color: str | None = None,
+        color: str | tuple[int, int, int] | None = None,
     ) -> bool:
         """Set night light settings.
 
         Args:
             mode: Night light mode.
             brightness: Brightness level (0-100).
-            color: Color hex string (e.g., "#FF0000").
+            color: Color hex string (e.g., "#FF0000") or RGB tuple.
 
         """
         value: dict[str, Any] = {}
@@ -751,7 +770,14 @@ class LitterRobot5(LitterRobot):
                 )
             value["brightness"] = brightness
         if color is not None:
-            value["color"] = color
+            try:
+                value["color"] = (
+                    rgb_to_hex(color)
+                    if isinstance(color, tuple)
+                    else rgb_to_hex(hex_to_rgb(color))
+                )
+            except ValueError as ex:
+                raise InvalidCommandException(f"Invalid color: {color!r}") from ex
         if not value:
             raise InvalidCommandException(
                 "At least one of mode, brightness, or color must be provided."

--- a/pylitterbot/utils.py
+++ b/pylitterbot/utils.py
@@ -52,6 +52,27 @@ def encode(value: str | dict) -> str:
     return b64encode(value.encode(ENCODING)).decode(ENCODING)
 
 
+def hex_to_rgb(value: str) -> tuple[int, int, int]:
+    """Convert a color hex string to an RGB tuple.
+
+    Accepts "#RGB", "#RRGGBB" and "#RRGGBBAA" (the Litter-Robot API may store
+    a trailing alpha byte, which is ignored). Raises ValueError otherwise.
+    """
+    color = value.lstrip("#")
+    if len(color) == 3:
+        color = "".join(component * 2 for component in color)
+    if len(color) not in (6, 8) or not re.fullmatch(r"[0-9A-Fa-f]+", color):
+        raise ValueError(f"Invalid color hex string: {value!r}")
+    return int(color[0:2], 16), int(color[2:4], 16), int(color[4:6], 16)
+
+
+def rgb_to_hex(rgb: tuple[int, int, int]) -> str:
+    """Convert an RGB tuple to an "#RRGGBB" color hex string."""
+    if any(not 0 <= channel <= 255 for channel in rgb):
+        raise ValueError(f"Invalid RGB tuple: {rgb!r}")
+    return "#{:02X}{:02X}{:02X}".format(*rgb)
+
+
 def to_timestamp(timestamp: str | int | float | None) -> datetime | None:
     """Construct a UTC offset-aware datetime from a Litter-Robot API timestamp."""
     if not timestamp:

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -66,6 +66,7 @@ async def test_litter_robot_5(
     assert robot.name == "Robo-shitter"
     assert robot.night_light_brightness == 70
     assert robot.night_light_color == "#665F5F"
+    assert robot.night_light_rgb_color == (102, 95, 95)
     assert robot.night_light_level is None  # 70 doesn't map to LOW/MEDIUM/HIGH
     assert robot.night_light_mode == NightLightMode.AUTO
     assert robot.night_light_mode_enabled
@@ -1279,5 +1280,12 @@ async def test_litter_robot_5_set_night_light_settings(
     mock_aiointercept.patch(patch_url, payload={})
     result = await robot.set_night_light_settings(brightness=50, color="#FF0000")
     assert result is True
+
+    mock_aiointercept.patch(patch_url, payload={})
+    result = await robot.set_night_light_settings(color=(131, 255, 91))
+    assert result is True
+
+    with pytest.raises(InvalidCommandException):
+        await robot.set_night_light_settings(color="#NOTHEX")
 
     await robot._account.disconnect()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,14 @@
 """Test utils module."""
 
+import pytest
+
 from pylitterbot.utils import (
     REDACTED,
     decode,
     encode,
     first_value,
+    hex_to_rgb,
+    rgb_to_hex,
     redact,
     round_time,
     to_timestamp,
@@ -50,3 +54,25 @@ def test_first_value() -> None:
     assert first_value(values, ("key3", "key5")) is None
     assert first_value(values, ("key3", "key5"), 0) == 0
     assert first_value(None, ("key3", "key5"), 10) == 10
+
+
+def test_hex_to_rgb() -> None:
+    """Test converting color hex strings to RGB tuples."""
+    assert hex_to_rgb("#FF0000") == (255, 0, 0)
+    assert hex_to_rgb("83FF5B") == (131, 255, 91)
+    assert hex_to_rgb("#F0A") == (255, 0, 170)
+    assert hex_to_rgb("#83FF5B00") == (131, 255, 91)  # trailing alpha is ignored
+
+    for invalid in ("", "#12345", "#GG0000", "#123456789"):
+        with pytest.raises(ValueError):
+            hex_to_rgb(invalid)
+
+
+def test_rgb_to_hex() -> None:
+    """Test converting RGB tuples to color hex strings."""
+    assert rgb_to_hex((255, 0, 0)) == "#FF0000"
+    assert rgb_to_hex((131, 255, 91)) == "#83FF5B"
+
+    for invalid in ((256, 0, 0), (0, -1, 0)):
+        with pytest.raises(ValueError):
+            rgb_to_hex(invalid)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,8 +8,8 @@ from pylitterbot.utils import (
     encode,
     first_value,
     hex_to_rgb,
-    rgb_to_hex,
     redact,
+    rgb_to_hex,
     round_time,
     to_timestamp,
 )


### PR DESCRIPTION
Moves color hex parsing into the library so consumers get a typed RGB value instead of parsing the API string themselves:

- `hex_to_rgb`/`rgb_to_hex` utils handling `#RGB`, `#RRGGBB` and `#RRGGBBAA` (the API may store a trailing alpha byte, which is ignored)
- `LitterRobot5.night_light_rgb_color` property returning an RGB tuple
- `set_night_light_settings` `color` accepts an RGB tuple; string input is now validated and normalized to `#RRGGBB` (previously passed through unchecked)

Motivated by review feedback on home-assistant/core#174508.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading the night light color as an RGB tuple.
  * Night light color settings now accept either hex strings or RGB tuples.

* **Bug Fixes**
  * Improved color validation so invalid color values are rejected with a clear error.
  * Added broader color conversion handling, including shorthand and 8-digit hex formats.

* **Tests**
  * Expanded coverage for color conversion and night light color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->