### PR TITLE
feat: add camera video clip playback via signed CloudFront cookies

### DIFF
--- a/pylitterbot/camera.py
+++ b/pylitterbot/camera.py
@@ -179,6 +179,27 @@ class VideoClip:
         )
 
 
+@dataclass
+class VideoPlayback:
+    """Signed playback details for a recorded video clip.
+
+    The ``hls_url`` on a :class:`VideoClip` is unsigned and is rejected by the
+    CDN with HTTP 403.  :meth:`CameraClient.get_video_playback` exchanges a clip
+    id for short-lived CloudFront signed cookies; send them (see
+    :attr:`cookie_header`) when fetching the HLS playlist and its segments.
+    """
+
+    clip_id: str
+    hls_url: str | None
+    cookies: dict[str, str]
+    raw: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    @property
+    def cookie_header(self) -> str:
+        """Return the cookies formatted as an HTTP ``Cookie`` header value."""
+        return "; ".join(f"{name}={value}" for name, value in self.cookies.items())
+
+
 class CameraClient:
     """REST client for LR5 Pro camera APIs.
 
@@ -343,6 +364,53 @@ class CameraClient:
             VideoClip.from_response(item) for item in data if isinstance(item, dict)
         ]
         return clips[:limit] if limit is not None else clips
+
+    async def get_video_playback(self, clip_id: str) -> VideoPlayback | None:
+        """Fetch signed playback details for a recorded clip.
+
+        The clip's ``hlsUrl`` (from :meth:`get_videos`) is unsigned and is
+        rejected by the CDN with HTTP 403.  The clip-detail endpoint responds
+        with the CloudFront signed cookies (``CloudFront-Policy``,
+        ``CloudFront-Signature`` and ``CloudFront-Key-Pair-Id``) required to
+        stream it; pass them as a ``Cookie`` header when fetching the ``.m3u8``
+        playlist and its segments.
+
+        Args:
+            clip_id: The :attr:`VideoClip.id` of the clip to play.
+
+        Returns:
+            A :class:`VideoPlayback`, or ``None`` on API failure. The cookies
+            are short-lived, so fetch and use them promptly.
+
+        """
+        # The detail endpoint lives under ``camera-videos`` (not the per-device
+        # ``cameras/{id}/videos`` listing) and sets the CloudFront cookies as
+        # response headers, so it must be read from the raw session rather than
+        # the JSON-only ``_get`` helper.
+        url = f"{CAMERA_INVENTORY_API}/prod/v1/camera-videos/{quote(str(clip_id))}"
+        headers = self._settings_headers()
+        if (auth := await self._session.get_bearer_authorization()) is not None:
+            headers["authorization"] = auth
+        try:
+            async with self.websession.get(url, headers=headers) as resp:
+                resp.raise_for_status()
+                data = await resp.json()
+                cookies = {
+                    name: morsel.value
+                    for name, morsel in resp.cookies.items()
+                    if name.startswith("CloudFront-")
+                }
+        except _API_ERRORS as err:
+            _LOGGER.debug("Camera video playback %s failed: %s", clip_id, err)
+            return None
+        if not isinstance(data, dict):
+            return None
+        return VideoPlayback(
+            clip_id=str(clip_id),
+            hls_url=data.get("hlsUrl"),
+            cookies=cookies,
+            raw=data,
+        )
 
     async def get_events(self, *, limit: int | None = None) -> list[dict[str, Any]]:
         """Fetch camera events (AI detections, etc.).

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -16,9 +16,11 @@ from pylitterbot import Account
 from pylitterbot.camera import (
     CAMERA_CANVAS_FRONT,
     CAMERA_CANVAS_GLOBE,
+    CAMERA_INVENTORY_API,
     CameraClient,
     CameraSession,
     VideoClip,
+    VideoPlayback,
     _decode_sdp,
     _parse_signaling_message,
 )
@@ -128,6 +130,26 @@ class TestVideoClip:
         assert clip.thumbnail_url is None
         assert clip.event_type is None
         assert clip.created_at is None
+
+
+class TestVideoPlayback:
+    """Tests for VideoPlayback dataclass."""
+
+    def test_cookie_header(self) -> None:
+        """Cookies render as an HTTP Cookie header value."""
+        playback = VideoPlayback(
+            clip_id="12345",
+            hls_url="https://cdn.example/clip.m3u8",
+            cookies={"CloudFront-Policy": "abc", "CloudFront-Signature": "def"},
+        )
+        assert playback.cookie_header == (
+            "CloudFront-Policy=abc; CloudFront-Signature=def"
+        )
+
+    def test_cookie_header_empty(self) -> None:
+        """No cookies yields an empty Cookie header."""
+        playback = VideoPlayback(clip_id="1", hls_url=None, cookies={})
+        assert playback.cookie_header == ""
 
 
 class TestCameraClient:
@@ -264,6 +286,90 @@ class TestCameraClient:
         videos = await client.get_videos(limit=1)
         assert len(videos) == 1
         assert videos[0].id == str(CAMERA_VIDEOS_RESPONSE[0]["id"])
+
+        await mock_account.disconnect()
+
+    async def test_get_video_playback(
+        self,
+        mock_account: Account,
+        mock_aiointercept: aiointercept,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Test fetching signed playback details (HLS URL + CloudFront cookies)."""
+        clip_id = "12345"
+        mock_aiointercept.get(
+            f"{CAMERA_INVENTORY_API}/prod/v1/camera-videos/{clip_id}",
+            payload={"id": clip_id, "hlsUrl": "https://cdn.example/clip.m3u8"},
+            headers=CIMultiDict(
+                [
+                    ("Set-Cookie", "CloudFront-Policy=pol; Path=/"),
+                    ("Set-Cookie", "CloudFront-Signature=sig; Path=/"),
+                    ("Set-Cookie", "CloudFront-Key-Pair-Id=kid; Path=/"),
+                    ("Set-Cookie", "session=nope; Path=/"),
+                ]
+            ),
+        )
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+
+        async def _bearer() -> str:
+            return "Bearer test-token"
+
+        monkeypatch.setattr(mock_account.session, "get_bearer_authorization", _bearer)
+        playback = await client.get_video_playback(clip_id)
+        assert isinstance(playback, VideoPlayback)
+        assert playback.clip_id == clip_id
+        assert playback.hls_url == "https://cdn.example/clip.m3u8"
+        # only CloudFront-* cookies are kept (the "session" cookie is dropped)
+        assert playback.cookies == {
+            "CloudFront-Policy": "pol",
+            "CloudFront-Signature": "sig",
+            "CloudFront-Key-Pair-Id": "kid",
+        }
+        assert "CloudFront-Policy=pol" in playback.cookie_header
+
+        await mock_account.disconnect()
+
+    async def test_get_video_playback_failure_returns_none(
+        self,
+        mock_account: Account,
+        mock_aiointercept: aiointercept,
+    ) -> None:
+        """Test that an API error yields None rather than raising."""
+        clip_id = "99999"
+        mock_aiointercept.get(
+            f"{CAMERA_INVENTORY_API}/prod/v1/camera-videos/{clip_id}",
+            status=403,
+        )
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        assert await client.get_video_playback(clip_id) is None
+
+        await mock_account.disconnect()
+
+    async def test_get_video_playback_non_dict_returns_none(
+        self,
+        mock_account: Account,
+        mock_aiointercept: aiointercept,
+    ) -> None:
+        """Test that an unexpected (non-object) response yields None."""
+        clip_id = "88888"
+        mock_aiointercept.get(
+            f"{CAMERA_INVENTORY_API}/prod/v1/camera-videos/{clip_id}",
+            payload=["unexpected"],
+        )
+        client = CameraClient(
+            session=mock_account.session,
+            device_id=CAMERA_DEVICE_ID,
+            api_key="test-key",
+        )
+        assert await client.get_video_playback(clip_id) is None
 
         await mock_account.disconnect()
 


### PR DESCRIPTION
`get_videos()` returns each recorded clip's `hlsUrl`, but that URL is unsigned — CloudFront rejects it with HTTP 403, so clips can't be played or downloaded.

This adds `CameraClient.get_video_playback(clip_id)`, which reads the clip detail endpoint (`/prod/v1/camera-videos/{id}`) to obtain the short-lived CloudFront signed cookies (`CloudFront-Policy` / `-Signature` / `-Key-Pair-Id`) required to stream the HLS playlist and its segments. It returns a `VideoPlayback` dataclass (`hls_url`, `cookies`, `cookie_header`, `raw`).

### Why read from the raw session
The detail endpoint delivers the auth as **Set-Cookie response headers**, so it's read via `self.websession` directly rather than the `_get` / `Session.get` helper (which only returns parsed JSON and drops headers). The bearer + `x-api-key` are attached the same way the other camera endpoints authenticate.

### Notes
- Errors and non-object responses return `None`, matching `get_videos`.
- Cookie values are passed through verbatim (as the app does) — no re-encoding.

### Testing
- Unit tests: success + CloudFront-only cookie filtering, `403 → None`, non-object → `None`, and the `cookie_header` property.
- Verified live against an LR5 Pro: the `.m3u8` returns 200 with the cookies and 403 without.
- `mypy pylitterbot tests`, `ruff check` / `ruff format`, and the full suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving signed playback details for recorded camera clips.
  * Playback responses now include the HLS stream URL and required secure playback cookies.
  * Added convenient formatting for playback cookies in HTTP request headers.

* **Bug Fixes**
  * Gracefully handles playback API errors and unexpected response formats by returning no playback result.

* **Tests**
  * Added coverage for successful playback retrieval, cookie filtering, formatting, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->