### PR TITLE
Add websocket stale watchdog

### DIFF
--- a/pylitterbot/robot/litterrobot3.py
+++ b/pylitterbot/robot/litterrobot3.py
@@ -30,6 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_ENDPOINT = API_V2_ENDPOINT
 WEBSOCKET_ENDPOINT = "https://8s1fz54a82.execute-api.us-east-1.amazonaws.com/prod"
+WEBSOCKET_STALE_TIMEOUT_SECONDS = 3600.0
 
 SLEEP_MODE_ACTIVE = "sleepModeActive"
 SLEEP_MODE_TIME = "sleepModeTime"
@@ -327,6 +328,7 @@ class LitterRobot3(LitterRobot):
         ws_config_factory=_ws_config_factory,
         subscribe_factory=_ws_subscribe,
         message_handler=_ws_message_handler,
+        stale_timeout=WEBSOCKET_STALE_TIMEOUT_SECONDS,
     )
 
     def _build_transport(self) -> WebSocketMonitor:

--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -211,7 +211,7 @@ class WebSocketMonitor(Transport):
                             ws.receive(), timeout=self._stale_timeout
                         )
                     except asyncio.TimeoutError:
-                        idle_seconds = (
+                        stale_seconds = (
                             (utcnow() - self._last_received).total_seconds()
                             if self._last_received is not None
                             else self._stale_timeout
@@ -219,7 +219,7 @@ class WebSocketMonitor(Transport):
                         _LOGGER.warning(
                             "WebSocket stale after %.1fs without a message; "
                             "reconnecting",
-                            idle_seconds,
+                            stale_seconds,
                         )
                         await ws.close()
                         return
@@ -228,7 +228,7 @@ class WebSocketMonitor(Transport):
                         await ws.close()
                         return
                     received_at = utcnow()
-                    previous_received = self._last_received
+                    previous_received: datetime | None = self._last_received
                     self._last_received = received_at
                     if msg.type == WSMsgType.TEXT:
                         try:
@@ -243,7 +243,7 @@ class WebSocketMonitor(Transport):
                         message_type = (
                             data.get("type") if isinstance(data, dict) else None
                         )
-                        idle_seconds = (
+                        idle_seconds: float | None = (
                             (received_at - previous_received).total_seconds()
                             if previous_received is not None
                             else None

--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 _RobotT = TypeVar("_RobotT", bound="Robot")
 
 BACKOFF_SECONDS_MAX = 300.0
+WEBSOCKET_STALE_TIMEOUT_SECONDS = 180.0
 
 
 async def cancel_task(*tasks: asyncio.Task | None) -> None:
@@ -76,10 +77,12 @@ class WebSocketMonitor(Transport):
         self,
         protocol: WebSocketProtocol,
         reconnect_base: float = 1.0,
+        stale_timeout: float = WEBSOCKET_STALE_TIMEOUT_SECONDS,
     ) -> None:
         """Initialize a WebSocket monitor."""
         self._protocol = protocol
         self._reconnect_base = reconnect_base
+        self._stale_timeout = stale_timeout
 
         self._listeners: dict[str, Robot] = {}
         self._task: asyncio.Task | None = None
@@ -201,16 +204,71 @@ class WebSocketMonitor(Transport):
                         for robot in list(self._listeners.values()):
                             await self._protocol.subscribe_factory(robot, ws)
 
-                async for msg in ws:
+                self._last_received = None
+                while not self._stop_event.is_set():
+                    try:
+                        msg = await asyncio.wait_for(
+                            ws.receive(), timeout=self._stale_timeout
+                        )
+                    except asyncio.TimeoutError:
+                        idle_seconds = (
+                            (utcnow() - self._last_received).total_seconds()
+                            if self._last_received is not None
+                            else self._stale_timeout
+                        )
+                        _LOGGER.warning(
+                            "WebSocket stale after %.1fs without a message; "
+                            "reconnecting",
+                            idle_seconds,
+                        )
+                        await ws.close()
+                        return
+
                     if self._stop_event.is_set():
                         await ws.close()
                         return
-                    self._last_received = utcnow()
+                    received_at = utcnow()
+                    previous_received = self._last_received
+                    self._last_received = received_at
                     if msg.type == WSMsgType.TEXT:
+                        data = msg.json()
+                        message_type = (
+                            data.get("type") if isinstance(data, dict) else None
+                        )
+                        idle_seconds = (
+                            (received_at - previous_received).total_seconds()
+                            if previous_received is not None
+                            else None
+                        )
+                        if message_type == "ka":
+                            _LOGGER.debug(
+                                "WebSocket keepalive received%s",
+                                (
+                                    f" after {idle_seconds:.1f}s"
+                                    if idle_seconds is not None
+                                    else ""
+                                ),
+                            )
+                        elif message_type in {
+                            "start_ack",
+                            "complete",
+                            "data",
+                            "error",
+                        }:
+                            _LOGGER.debug(
+                                "WebSocket message received: type=%s%s",
+                                message_type,
+                                (
+                                    f" after {idle_seconds:.1f}s"
+                                    if idle_seconds is not None
+                                    else ""
+                                ),
+                            )
+
                         if self._protocol.message_handler:
                             for robot in list(self._listeners.values()):
                                 try:
-                                    self._protocol.message_handler(robot, msg.json())
+                                    self._protocol.message_handler(robot, data)
                                 except Exception:
                                     _LOGGER.exception(
                                         "Error dispatching WS message to %r", robot

--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -231,7 +231,15 @@ class WebSocketMonitor(Transport):
                     previous_received = self._last_received
                     self._last_received = received_at
                     if msg.type == WSMsgType.TEXT:
-                        data = msg.json()
+                        try:
+                            data = msg.json()
+                        except ValueError:
+                            _LOGGER.debug(
+                                "WebSocket message JSON decode failed",
+                                exc_info=True,
+                            )
+                            continue
+
                         message_type = (
                             data.get("type") if isinstance(data, dict) else None
                         )
@@ -273,7 +281,12 @@ class WebSocketMonitor(Transport):
                                     _LOGGER.exception(
                                         "Error dispatching WS message to %r", robot
                                     )
-                    elif msg.type in (WSMsgType.ERROR, WSMsgType.CLOSE):
+                    elif msg.type in (
+                        WSMsgType.ERROR,
+                        WSMsgType.CLOSE,
+                        WSMsgType.CLOSING,
+                        WSMsgType.CLOSED,
+                    ):
                         break
             finally:
                 self._ws = None

--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -49,6 +49,7 @@ class WebSocketProtocol(Generic[_RobotT]):
     ) = None
     message_handler: Callable[[_RobotT, dict], None] | None = None
     is_shared: bool = False
+    stale_timeout: float = WEBSOCKET_STALE_TIMEOUT_SECONDS
 
 
 class Transport(ABC):
@@ -77,12 +78,11 @@ class WebSocketMonitor(Transport):
         self,
         protocol: WebSocketProtocol,
         reconnect_base: float = 1.0,
-        stale_timeout: float = WEBSOCKET_STALE_TIMEOUT_SECONDS,
     ) -> None:
         """Initialize a WebSocket monitor."""
         self._protocol = protocol
         self._reconnect_base = reconnect_base
-        self._stale_timeout = stale_timeout
+        self._stale_timeout = protocol.stale_timeout
 
         self._listeners: dict[str, Robot] = {}
         self._task: asyncio.Task | None = None

--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -248,16 +248,7 @@ class WebSocketMonitor(Transport):
                             if previous_received is not None
                             else None
                         )
-                        if message_type == "ka":
-                            _LOGGER.debug(
-                                "WebSocket keepalive received%s",
-                                (
-                                    f" after {idle_seconds:.1f}s"
-                                    if idle_seconds is not None
-                                    else ""
-                                ),
-                            )
-                        elif isinstance(message_type, str) and message_type in {
+                        if isinstance(message_type, str) and message_type in {
                             "start_ack",
                             "complete",
                             "data",

--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -257,7 +257,7 @@ class WebSocketMonitor(Transport):
                                     else ""
                                 ),
                             )
-                        elif message_type in {
+                        elif isinstance(message_type, str) and message_type in {
                             "start_ack",
                             "complete",
                             "data",

--- a/tests/test_litterrobot3.py
+++ b/tests/test_litterrobot3.py
@@ -22,7 +22,6 @@ from pylitterbot.robot.litterrobot3 import (
     SLEEP_MODE_ACTIVE,
     SLEEP_MODE_TIME,
     UNIT_STATUS,
-    WEBSOCKET_STALE_TIMEOUT_SECONDS,
     LitterRobot,
     LitterRobot3,
 )
@@ -49,7 +48,7 @@ async def test_litter_robot_3_websocket_stale_timeout(mock_account: Account) -> 
 
     transport = robot._build_transport()
 
-    assert transport._stale_timeout == WEBSOCKET_STALE_TIMEOUT_SECONDS
+    assert transport._stale_timeout == 3600.0
 
 
 async def test_litter_robot_3_setup(

--- a/tests/test_litterrobot3.py
+++ b/tests/test_litterrobot3.py
@@ -22,6 +22,7 @@ from pylitterbot.robot.litterrobot3 import (
     SLEEP_MODE_ACTIVE,
     SLEEP_MODE_TIME,
     UNIT_STATUS,
+    WEBSOCKET_STALE_TIMEOUT_SECONDS,
     LitterRobot,
     LitterRobot3,
 )
@@ -40,6 +41,15 @@ from .common import (
 )
 
 pytestmark = pytest.mark.asyncio
+
+
+async def test_litter_robot_3_websocket_stale_timeout(mock_account: Account) -> None:
+    """Test LR3 allows longer idle WebSocket connections."""
+    robot = LitterRobot3(data=ROBOT_DATA, account=mock_account)
+
+    transport = robot._build_transport()
+
+    assert transport._stale_timeout == WEBSOCKET_STALE_TIMEOUT_SECONDS
 
 
 async def test_litter_robot_3_setup(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,13 +1,74 @@
 """Test transport layer."""
 
 import asyncio
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from pylitterbot.transport import PollingTransport
+from pylitterbot.transport import PollingTransport, WebSocketMonitor, WebSocketProtocol
 
 pytestmark = pytest.mark.asyncio
+
+
+class FakeWebSocket:
+    """Fake WebSocket that never receives a message."""
+
+    closed = False
+
+    async def receive(self) -> None:
+        """Block long enough for the monitor receive timeout to fire."""
+        await asyncio.sleep(60)
+
+    async def close(self) -> None:
+        """Close the fake WebSocket."""
+        self.closed = True
+
+
+class FakeWebSocketContext:
+    """Async context manager for the fake WebSocket."""
+
+    def __init__(self, ws: FakeWebSocket) -> None:
+        """Initialize the context manager."""
+        self.ws = ws
+
+    async def __aenter__(self) -> FakeWebSocket:
+        """Enter the fake WebSocket context."""
+        return self.ws
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the fake WebSocket context."""
+        return None
+
+
+async def test_websocket_monitor_reconnects_after_stale_receive() -> None:
+    """Test WebSocket monitor closes a stale connection so it can reconnect."""
+    ws = FakeWebSocket()
+    robot = SimpleNamespace(
+        id="robot-1",
+        _account=SimpleNamespace(
+            session=SimpleNamespace(
+                websession=SimpleNamespace(
+                    ws_connect=Mock(return_value=FakeWebSocketContext(ws))
+                )
+            )
+        ),
+    )
+
+    async def ws_config_factory(robot: object) -> dict[str, str]:
+        """Return fake WebSocket configuration."""
+        return {"url": "wss://example.test/graphql/realtime"}
+
+    transport = WebSocketMonitor(
+        WebSocketProtocol(ws_config_factory=ws_config_factory),
+        stale_timeout=0.01,
+    )
+    transport._listeners[robot.id] = robot
+
+    await transport._connect()
+
+    assert ws.closed is True
+    assert transport._ws is None
 
 
 async def test_polling_transport_calls_refresh() -> None:

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -79,7 +79,7 @@ async def test_websocket_monitor_reconnects_after_stale_receive() -> None:
         ),
     )
 
-    async def ws_config_factory(robot: object) -> dict[str, str]:
+    async def ws_config_factory(robot: object) -> dict[str, Any]:
         """Return fake WebSocket configuration."""
         return {"url": "wss://example.test/graphql/realtime"}
 
@@ -109,7 +109,7 @@ async def test_websocket_monitor_breaks_on_closed_message() -> None:
         ),
     )
 
-    async def ws_config_factory(robot: object) -> dict[str, str]:
+    async def ws_config_factory(robot: object) -> dict[str, Any]:
         """Return fake WebSocket configuration."""
         return {"url": "wss://example.test/graphql/realtime"}
 
@@ -139,7 +139,7 @@ async def test_websocket_monitor_ignores_invalid_json_message() -> None:
     )
     message_handler = Mock()
 
-    async def ws_config_factory(robot: object) -> dict[str, str]:
+    async def ws_config_factory(robot: object) -> dict[str, Any]:
         """Return fake WebSocket configuration."""
         return {"url": "wss://example.test/graphql/realtime"}
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -68,7 +68,7 @@ class FakeWebSocketContext:
 async def test_websocket_monitor_reconnects_after_stale_receive() -> None:
     """Test WebSocket monitor closes a stale connection so it can reconnect."""
     ws = FakeWebSocket()
-    robot = SimpleNamespace(
+    robot: Any = SimpleNamespace(
         id="robot-1",
         _account=SimpleNamespace(
             session=SimpleNamespace(
@@ -98,7 +98,7 @@ async def test_websocket_monitor_reconnects_after_stale_receive() -> None:
 async def test_websocket_monitor_breaks_on_closed_message() -> None:
     """Test WebSocket monitor exits when aiohttp reports a closed WebSocket."""
     ws = FakeMessageWebSocket(Mock(type=WSMsgType.CLOSED))
-    robot = SimpleNamespace(
+    robot: Any = SimpleNamespace(
         id="robot-1",
         _account=SimpleNamespace(
             session=SimpleNamespace(
@@ -127,7 +127,7 @@ async def test_websocket_monitor_ignores_invalid_json_message() -> None:
     bad_message = Mock(type=WSMsgType.TEXT)
     bad_message.json.side_effect = ValueError
     ws = FakeMessageWebSocket(bad_message, Mock(type=WSMsgType.CLOSED))
-    robot = SimpleNamespace(
+    robot: Any = SimpleNamespace(
         id="robot-1",
         _account=SimpleNamespace(
             session=SimpleNamespace(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,10 +1,13 @@
 """Test transport layer."""
 
 import asyncio
+from collections import deque
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from aiohttp import WSMsgType
 
 from pylitterbot.transport import PollingTransport, WebSocketMonitor, WebSocketProtocol
 
@@ -16,9 +19,30 @@ class FakeWebSocket:
 
     closed = False
 
-    async def receive(self) -> None:
+    async def receive(self) -> Mock:
         """Block long enough for the monitor receive timeout to fire."""
         await asyncio.sleep(60)
+        return Mock(type=None)
+
+    async def close(self) -> None:
+        """Close the fake WebSocket."""
+        self.closed = True
+
+
+class FakeMessageWebSocket:
+    """Fake WebSocket that returns predefined messages."""
+
+    closed = False
+
+    def __init__(self, *messages: Mock) -> None:
+        """Initialize the fake WebSocket."""
+        self.messages = deque(messages)
+        self.receive_count = 0
+
+    async def receive(self) -> Mock:
+        """Return the next fake WebSocket message."""
+        self.receive_count += 1
+        return self.messages.popleft()
 
     async def close(self) -> None:
         """Close the fake WebSocket."""
@@ -28,11 +52,11 @@ class FakeWebSocket:
 class FakeWebSocketContext:
     """Async context manager for the fake WebSocket."""
 
-    def __init__(self, ws: FakeWebSocket) -> None:
+    def __init__(self, ws: Any) -> None:
         """Initialize the context manager."""
         self.ws = ws
 
-    async def __aenter__(self) -> FakeWebSocket:
+    async def __aenter__(self) -> Any:
         """Enter the fake WebSocket context."""
         return self.ws
 
@@ -68,6 +92,69 @@ async def test_websocket_monitor_reconnects_after_stale_receive() -> None:
     await transport._connect()
 
     assert ws.closed is True
+    assert transport._ws is None
+
+
+async def test_websocket_monitor_breaks_on_closed_message() -> None:
+    """Test WebSocket monitor exits when aiohttp reports a closed WebSocket."""
+    ws = FakeMessageWebSocket(Mock(type=WSMsgType.CLOSED))
+    robot = SimpleNamespace(
+        id="robot-1",
+        _account=SimpleNamespace(
+            session=SimpleNamespace(
+                websession=SimpleNamespace(
+                    ws_connect=Mock(return_value=FakeWebSocketContext(ws))
+                )
+            )
+        ),
+    )
+
+    async def ws_config_factory(robot: object) -> dict[str, str]:
+        """Return fake WebSocket configuration."""
+        return {"url": "wss://example.test/graphql/realtime"}
+
+    transport = WebSocketMonitor(WebSocketProtocol(ws_config_factory=ws_config_factory))
+    transport._listeners[robot.id] = robot
+
+    await transport._connect()
+
+    assert ws.receive_count == 1
+    assert transport._ws is None
+
+
+async def test_websocket_monitor_ignores_invalid_json_message() -> None:
+    """Test WebSocket monitor continues after a malformed text message."""
+    bad_message = Mock(type=WSMsgType.TEXT)
+    bad_message.json.side_effect = ValueError
+    ws = FakeMessageWebSocket(bad_message, Mock(type=WSMsgType.CLOSED))
+    robot = SimpleNamespace(
+        id="robot-1",
+        _account=SimpleNamespace(
+            session=SimpleNamespace(
+                websession=SimpleNamespace(
+                    ws_connect=Mock(return_value=FakeWebSocketContext(ws))
+                )
+            )
+        ),
+    )
+    message_handler = Mock()
+
+    async def ws_config_factory(robot: object) -> dict[str, str]:
+        """Return fake WebSocket configuration."""
+        return {"url": "wss://example.test/graphql/realtime"}
+
+    transport = WebSocketMonitor(
+        WebSocketProtocol(
+            ws_config_factory=ws_config_factory,
+            message_handler=message_handler,
+        )
+    )
+    transport._listeners[robot.id] = robot
+
+    await transport._connect()
+
+    assert ws.receive_count == 2
+    assert message_handler.call_count == 0
     assert transport._ws is None
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -124,11 +124,18 @@ async def test_websocket_monitor_breaks_on_closed_message() -> None:
     assert transport._ws is None
 
 
-async def test_websocket_monitor_ignores_invalid_json_message() -> None:
-    """Test WebSocket monitor continues after a malformed text message."""
+async def test_websocket_monitor_handles_invalid_text_messages() -> None:
+    """Test WebSocket monitor continues after invalid text messages."""
     bad_message = Mock(type=WSMsgType.TEXT)
     bad_message.json.side_effect = ValueError
-    ws = FakeMessageWebSocket(bad_message, Mock(type=WSMsgType.CLOSED))
+    unhashable_type_message = Mock(type=WSMsgType.TEXT)
+    data = {"type": []}
+    unhashable_type_message.json.return_value = data
+    ws = FakeMessageWebSocket(
+        bad_message,
+        unhashable_type_message,
+        Mock(type=WSMsgType.CLOSED),
+    )
     robot: Any = SimpleNamespace(
         id="robot-1",
         _account=SimpleNamespace(
@@ -155,8 +162,8 @@ async def test_websocket_monitor_ignores_invalid_json_message() -> None:
 
     await transport._connect()
 
-    assert ws.receive_count == 2
-    assert message_handler.call_count == 0
+    assert ws.receive_count == 3
+    message_handler.assert_called_once_with(robot, data)
     assert transport._ws is None
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -84,8 +84,10 @@ async def test_websocket_monitor_reconnects_after_stale_receive() -> None:
         return {"url": "wss://example.test/graphql/realtime"}
 
     transport = WebSocketMonitor(
-        WebSocketProtocol(ws_config_factory=ws_config_factory),
-        stale_timeout=0.01,
+        WebSocketProtocol(
+            ws_config_factory=ws_config_factory,
+            stale_timeout=0.01,
+        )
     )
     transport._listeners[robot.id] = robot
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -129,7 +129,7 @@ async def test_websocket_monitor_handles_invalid_text_messages() -> None:
     bad_message = Mock(type=WSMsgType.TEXT)
     bad_message.json.side_effect = ValueError
     unhashable_type_message = Mock(type=WSMsgType.TEXT)
-    data = {"type": []}
+    data: dict[str, Any] = {"type": []}
     unhashable_type_message.json.return_value = data
     ws = FakeMessageWebSocket(
         bad_message,


### PR DESCRIPTION
## Summary

Add a stale WebSocket watchdog to the shared WebSocket monitor. The monitor now uses a timed receive loop, logs keepalive/message timing, and closes the socket when no WebSocket message arrives for the configured stale timeout so the existing reconnect loop can establish a fresh connection.

## Root cause

Some internet providers reconnect the connection daily and assign a new IP address. In that situation the existing aiohttp WebSocket receive loop can become stale without raising an exception. The monitor then waits forever, so Litter-Robot updates stop arriving until Home Assistant or the integration is restarted.

## Impact

When a connection goes stale silently, pylitterbot will now close the WebSocket after 180 seconds without any message and reconnect. This preserves normal operation where the server sends keepalives about every 60 seconds, while avoiding false positives for short transient delays.

## Validation

- `uv run pytest tests/test_transport.py -q`
- `uv run ruff check pylitterbot/transport.py tests/test_transport.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable WebSocket inactivity detection with automatic reconnection.
  * Configured the Litter-Robot 3 connection with a one-hour inactivity timeout.

* **Bug Fixes**
  * Improved handling of stalled, closed, or errored WebSocket connections.
  * Safely ignores malformed messages without interrupting communication.
  * Ensured cleaner shutdown when stopping WebSocket monitoring.

* **Tests**
  * Added coverage for timeout recovery, closed connections, malformed messages, and Litter-Robot 3 timeout configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->