### PR TITLE
fix: correct LitterHopper status reporting on Litter-Robot 5

### DIFF
--- a/pylitterbot/enums.py
+++ b/pylitterbot/enums.py
@@ -234,7 +234,11 @@ class HopperStatus(Enum):
     MOTOR_OT_AMPS = "MOTOR_OT_AMPS"
     MOTOR_DISCONNECTED = "MOTOR_DISCONNECTED"
     EMPTY = "EMPTY"
+    # Reported by an LR5's hopperStatusIndicator. LITTER_LOW is not sticky: a
+    # refilled hopper re-measures and moves to READY (observed ~75 min and
+    # several dispenses after topping one up, alongside hopperLitterLevel 0->1).
     LITTER_LOW = "LITTER_LOW"
+    READY = "READY"
 
 
 @unique

--- a/pylitterbot/enums.py
+++ b/pylitterbot/enums.py
@@ -74,10 +74,14 @@ class LitterRobot5Command:
     ONBOARD_PTAG_OFF = "ONBOARD_PTAG_OFF"
     PRIVACY_MODE_ON = "PRIVACY_MODE_ON"
     PRIVACY_MODE_OFF = "PRIVACY_MODE_OFF"
-    # Discovered via API 422 response but unverified on litter robot hardware:
+    # Accepted by the shared /commands schema but NOT implemented for a
+    # Litter-Robot 5 -- the endpoint advertises the same enum for every product
+    # line. Tested against an LR5 Pro with a LitterHopper attached:
     # NO_OP = "NO_OP"  # valid per API enum but returns INTERNAL_SERVER_ERROR
-    # FEED_NOW = "FEED_NOW"  # likely for Feeder-Robot or litter hopper accessory
-    # DISCARD_MEAL = "DISCARD_MEAL"  # likely for Feeder-Robot or litter hopper accessory
+    # FEED_NOW = "FEED_NOW"  # 500; does NOT dispense litter, hopper state unchanged
+    # DISCARD_MEAL = "DISCARD_MEAL"  # Feeder-Robot only; no meaning on a litter box
+    # There is no on-demand litter dispense command: the LitterHopper feeds the
+    # globe autonomously when it drops below `optimalLitterLevel`.
 
     # PATCH /robots/{serial} - settings keys
     CYCLE_DELAY = "cycleDelay"
@@ -230,6 +234,7 @@ class HopperStatus(Enum):
     MOTOR_OT_AMPS = "MOTOR_OT_AMPS"
     MOTOR_DISCONNECTED = "MOTOR_DISCONNECTED"
     EMPTY = "EMPTY"
+    LITTER_LOW = "LITTER_LOW"
 
 
 @unique

--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -311,8 +311,27 @@ class LitterRobot5(LitterRobot):
 
     @property
     def hopper_status(self) -> HopperStatus | None:
-        """Return the hopper status."""
+        """Return the hopper status.
+
+        The Litter-Robot 5 does not report a flat ``hopperStatus`` the way the
+        Litter-Robot 4 does; it sends ``hopperStatusIndicator``, a dict shaped
+        like ``{"title": "Litter Low", "value": "LITTER_LOW"}``. Reading the
+        LR4 key here meant this property was always ``None`` on an LR5 even
+        with a hopper attached and reporting. Prefer the indicator, and keep
+        the flat key as a fallback in case the API ever supplies it.
+        """
+        indicator = self._state.get("hopperStatusIndicator")
+        if isinstance(indicator, dict):
+            return to_enum(indicator.get("value"), HopperStatus)
         return to_enum(self._state.get("hopperStatus"), HopperStatus)
+
+    @property
+    def hopper_status_text(self) -> str | None:
+        """Return the human-readable hopper status (e.g. ``"Litter Low"``)."""
+        indicator = self._state.get("hopperStatusIndicator")
+        if isinstance(indicator, dict):
+            return cast(str | None, indicator.get("title"))
+        return None
 
     @property
     def is_bonnet_removed(self) -> bool:
@@ -341,8 +360,18 @@ class LitterRobot5(LitterRobot):
 
     @property
     def is_hopper_removed(self) -> bool:
-        """Return `True` if the hopper is removed/disabled."""
-        return self._state.get("isHopperInstalled") is False
+        """Return `True` if the hopper is removed or disabled.
+
+        ``isHopperInstalled`` tracks *physical attachment* only. Disabling the
+        hopper from the app leaves it ``True`` and instead reports
+        ``hopperStatusIndicator`` as ``DISABLED`` -- verified by toggling a
+        LitterHopper off and on against a Litter-Robot 5 Pro, where
+        ``isHopperInstalled`` never changed. Checking installation alone
+        therefore missed a disabled-but-attached hopper.
+        """
+        if self._state.get("isHopperInstalled") is False:
+            return True
+        return self.hopper_status is HopperStatus.DISABLED
 
     @property
     def is_laser_dirty(self) -> bool:

--- a/pylitterbot/robot/litterrobot5.py
+++ b/pylitterbot/robot/litterrobot5.py
@@ -321,7 +321,7 @@ class LitterRobot5(LitterRobot):
         the flat key as a fallback in case the API ever supplies it.
         """
         indicator = self._state.get("hopperStatusIndicator")
-        if isinstance(indicator, dict):
+        if isinstance(indicator, dict) and indicator.get("value") is not None:
             return to_enum(indicator.get("value"), HopperStatus)
         return to_enum(self._state.get("hopperStatus"), HopperStatus)
 

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -807,6 +807,13 @@ async def test_litter_robot_5_hopper_status_indicator(
     assert robot.hopper_status == HopperStatus.ENABLED
     assert robot.hopper_status_text is None
 
+    # READY: what a healthy, refilled hopper reports
+    data["state"]["hopperStatusIndicator"] = {"title": "Ready", "value": "READY"}
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status == HopperStatus.READY
+    assert robot.hopper_status_text == "Ready"
+    assert robot.is_hopper_removed is False
+
     # an indicator missing its value must not shadow the flat key
     data["state"]["hopperStatusIndicator"] = {"title": "Litter Low"}
     data["state"]["hopperStatus"] = "ENABLED"

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -775,6 +775,78 @@ async def test_litter_robot_5_hopper_statuses(
     await robot._account.disconnect()
 
 
+async def test_litter_robot_5_hopper_status_indicator(
+    mock_account: Account,
+) -> None:
+    """Tests the hopperStatusIndicator an LR5 actually reports.
+
+    A real Litter-Robot 5 with a LitterHopper attached sends
+    ``hopperStatusIndicator`` and no flat ``hopperStatus``; reading only the
+    latter left ``hopper_status`` as ``None`` on live hardware.
+    """
+    data = deepcopy(LITTER_ROBOT_5_DATA)
+    data["state"].pop("hopperStatus", None)
+    data["state"]["isHopperInstalled"] = True
+    data["state"]["hopperStatusIndicator"] = {
+        "title": "Litter Low",
+        "value": "LITTER_LOW",
+    }
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status == HopperStatus.LITTER_LOW
+    assert robot.hopper_status_text == "Litter Low"
+    assert robot.is_hopper_removed is False
+
+    # the indicator wins when both are present
+    data["state"]["hopperStatus"] = "ENABLED"
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status == HopperStatus.LITTER_LOW
+
+    # and the flat key still works when no indicator is sent
+    data["state"].pop("hopperStatusIndicator")
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status == HopperStatus.ENABLED
+    assert robot.hopper_status_text is None
+
+    # no hopper data at all
+    data["state"].pop("hopperStatus")
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status is None
+
+    await robot._account.disconnect()
+
+
+async def test_litter_robot_5_hopper_disabled_while_installed(
+    mock_account: Account,
+) -> None:
+    """A hopper disabled from the app stays physically installed.
+
+    Toggling a LitterHopper off on an LR5 leaves ``isHopperInstalled`` True and
+    reports ``hopperStatusIndicator`` DISABLED, so checking installation alone
+    reported a disabled hopper as present.
+    """
+    data = deepcopy(LITTER_ROBOT_5_DATA)
+    data["state"].pop("hopperStatus", None)
+    data["state"]["isHopperInstalled"] = True
+    data["state"]["hopperStatusIndicator"] = {"title": "Disabled", "value": "DISABLED"}
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status == HopperStatus.DISABLED
+    assert robot.hopper_status_text == "Disabled"
+    assert robot.is_hopper_removed is True
+
+    # enabled again: attached, reporting, not removed
+    data["state"]["hopperStatusIndicator"] = {"title": "Litter Low", "value": "LITTER_LOW"}
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status == HopperStatus.LITTER_LOW
+    assert robot.is_hopper_removed is False
+
+    # physically detached still counts as removed
+    data["state"]["isHopperInstalled"] = False
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.is_hopper_removed is True
+
+    await robot._account.disconnect()
+
+
 async def test_litter_robot_5_drawer_full_indicator(
     mock_account: Account,
 ) -> None:

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -807,8 +807,20 @@ async def test_litter_robot_5_hopper_status_indicator(
     assert robot.hopper_status == HopperStatus.ENABLED
     assert robot.hopper_status_text is None
 
-    # no hopper data at all
+    # an indicator missing its value must not shadow the flat key
+    data["state"]["hopperStatusIndicator"] = {"title": "Litter Low"}
+    data["state"]["hopperStatus"] = "ENABLED"
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status == HopperStatus.ENABLED
+
+    # ...nor invent a status when there is no flat key either
     data["state"].pop("hopperStatus")
+    robot = LitterRobot5(data=data, account=mock_account)
+    assert robot.hopper_status is None
+    data["state"].pop("hopperStatusIndicator")
+
+    # no hopper data at all
+    data["state"].pop("hopperStatus", None)
     robot = LitterRobot5(data=data, account=mock_account)
     assert robot.hopper_status is None
 

--- a/tests/test_litterrobot5.py
+++ b/tests/test_litterrobot5.py
@@ -834,7 +834,10 @@ async def test_litter_robot_5_hopper_disabled_while_installed(
     assert robot.is_hopper_removed is True
 
     # enabled again: attached, reporting, not removed
-    data["state"]["hopperStatusIndicator"] = {"title": "Litter Low", "value": "LITTER_LOW"}
+    data["state"]["hopperStatusIndicator"] = {
+        "title": "Litter Low",
+        "value": "LITTER_LOW",
+    }
     robot = LitterRobot5(data=data, account=mock_account)
     assert robot.hopper_status == HopperStatus.LITTER_LOW
     assert robot.is_hopper_removed is False


### PR DESCRIPTION
## Summary

Two properties were wrong for a Litter-Robot 5 with a LitterHopper attached, because both assumed the Litter-Robot 4's payload shape.

**`hopper_status` always returned `None` on an LR5.** It reads a flat `hopperStatus`, which an LR5 never sends — it reports `hopperStatusIndicator`, a dict:

```json
{"title": "Litter Low", "value": "LITTER_LOW"}
```

**`is_hopper_removed` missed a disabled hopper.** It's documented as "removed/disabled" but tests only `isHopperInstalled`, which tracks *physical attachment*. Disabling from the app leaves that `True` and moves the indicator to `DISABLED`, so a hopper the user had explicitly turned off still reported as present. The LR4 doesn't have this problem — `toggle_hopper` sets `isHopperRemoved` directly.

## Changes

- `hopper_status` prefers `hopperStatusIndicator`, falling back to the flat key
- adds `HopperStatus.LITTER_LOW` (reported by the indicator, missing from the enum)
- adds `hopper_status_text` for the human-readable title
- `is_hopper_removed` also returns `True` when the indicator says `DISABLED`
- records tested behaviour of `FEED_NOW` / `DISCARD_MEAL` / `NO_OP`

## Verification

Tested on a Litter-Robot 5 Pro with a LitterHopper, toggling it off and on from the app:

```
disable  hopperStatusIndicator  LITTER_LOW -> DISABLED
enable   hopperStatusIndicator  DISABLED   -> LITTER_LOW
isHopperInstalled              True throughout, never changed
```

| property | before | after |
|---|---|---|
| `hopper_status` | `None` | `HopperStatus.LITTER_LOW` / `DISABLED` |
| `hopper_status_text` | — | `'Litter Low'` / `'Disabled'` |
| `is_hopper_removed` | `False` while disabled | `True` |

## On the unimplemented commands

The `/commands` endpoint advertises one enum for every product line, so an LR5 accepts `FEED_NOW` in the schema. It isn't implemented for a litter box:

```
POST /robots/{serial}/commands  {"type": "FEED_NOW"}  ->  500 INTERNAL_SERVER_ERROR
```

Nothing changed on the robot afterwards — `hopperLastDispensed`, `hopperLitterLevel`, `litterLevelPercent` and `globeLitterLevel` were all identical, so it's rejected server-side rather than partially applied. This replaces the earlier `# likely for Feeder-Robot or litter hopper accessory` guess, which couldn't be checked without hopper hardware. There is no on-demand dispense command; the hopper feeds the globe on its own when it falls below `optimalLitterLevel` (observed three times while testing).

## Notes

The existing LR5 hopper tests set the flat `hopperStatus` key that the device never sends, which is why this went unnoticed. They still pass via the fallback. New tests cover the indicator shape, indicator-wins-over-flat-key, fallback, absent data, and disabled-while-installed.

**Correction to an earlier draft of this description:** I initially wrote that `hopperLitterLevel` never populates and that `LITTER_LOW` looked permanent. Continued monitoring disproved both. A refilled hopper re-measures and moves to `READY`, with the level going `0 -> 1` — about 75 minutes and several dispenses after the top-up, not immediately:

```
17:50  hopperStatusIndicator {'title': 'Litter Low', 'value': 'LITTER_LOW'}  level 0
19:08  hopperStatusIndicator {'title': 'Ready',      'value': 'READY'}       level 1
```

`READY` was missing from `HopperStatus` too, so a healthy hopper produced `Value 'READY' not found in enum HopperStatus` and fell back to `None`. Added.

Three indicator values are now observed on real hardware: `LITTER_LOW`, `DISABLED`, `READY`.

`ruff` clean; `pytest` green (the pre-existing `test_init.py::test_version` failure and the 10 pre-existing `mypy` findings in `litterrobot5.py` are unchanged on `main`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reporting for the Litter-Robot 5 “low litter” hopper status.
  - Exposes the hopper status label from the device’s indicator for clearer, human-readable updates.

- **Bug Fixes**
  - Hopper status now prefers the device indicator data when available, with safe fallback to older status fields when it isn’t.
  - Treats the hopper as removed when it’s reported as disabled, including cases where it’s still physically attached.

- **Tests**
  - Added coverage for indicator-based parsing and disabled-hopper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->