### PR TITLE
Stop the WebSocket monitor once the session is closed

### DIFF
--- a/pylitterbot/transport.py
+++ b/pylitterbot/transport.py
@@ -150,6 +150,18 @@ class WebSocketMonitor(Transport):
             except asyncio.TimeoutError:
                 await cancel_task(task_to_await)
 
+    def _session_closed(self) -> bool:
+        """Return whether the account session can still serve a connection.
+
+        An aiohttp session does not reopen once closed, so every later attempt
+        raises the same error. This is reached when the session is closed by
+        something other than `Account.disconnect`, which stops the monitor
+        before closing.
+        """
+        if (robot := next(iter(self._listeners.values()), None)) is None:
+            return False
+        return bool(robot._account.session.websession.closed)
+
     async def _run(self) -> None:
         """Run the WebSocket monitor."""
         delay = self._reconnect_base
@@ -160,6 +172,9 @@ class WebSocketMonitor(Transport):
             except asyncio.CancelledError:
                 break
             except Exception as exc:
+                if self._session_closed():
+                    _LOGGER.debug("Account session closed; stopping WebSocket monitor")
+                    break
                 if isinstance(exc, (ClientError, OSError)):
                     _LOGGER.warning(
                         "WebSocket error (%s); reconnecting in %.1fs", exc, delay

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -184,3 +184,58 @@ async def test_polling_transport_stops_cleanly() -> None:
     await transport.start(robot)
     await transport.stop(robot)  # should not block for 60 s
     assert transport._task is None or transport._task.done()
+
+
+async def test_websocket_monitor_stops_when_session_is_closed() -> None:
+    """Test the monitor stops instead of retrying against a closed session."""
+    websession = SimpleNamespace(
+        closed=True,
+        ws_connect=Mock(side_effect=RuntimeError("Session is closed")),
+    )
+    robot: Any = SimpleNamespace(
+        id="robot-1",
+        _account=SimpleNamespace(session=SimpleNamespace(websession=websession)),
+    )
+
+    async def ws_config_factory(_: object) -> dict[str, Any]:
+        """Return fake WebSocket configuration."""
+        return {"url": "wss://example.test/graphql/realtime"}
+
+    transport = WebSocketMonitor(
+        WebSocketProtocol(ws_config_factory=ws_config_factory, stale_timeout=0.01)
+    )
+    transport._listeners[robot.id] = robot
+    transport._reconnect_base = 30.0
+
+    await asyncio.wait_for(transport._run(), timeout=1.0)
+
+    assert websession.ws_connect.call_count == 1
+
+
+async def test_websocket_monitor_retries_while_session_is_open() -> None:
+    """Test an open session still reconnects after a failure."""
+    websession = SimpleNamespace(
+        closed=False,
+        ws_connect=Mock(side_effect=RuntimeError("boom")),
+    )
+    robot: Any = SimpleNamespace(
+        id="robot-1",
+        _account=SimpleNamespace(session=SimpleNamespace(websession=websession)),
+    )
+
+    async def ws_config_factory(_: object) -> dict[str, Any]:
+        """Return fake WebSocket configuration."""
+        return {"url": "wss://example.test/graphql/realtime"}
+
+    transport = WebSocketMonitor(
+        WebSocketProtocol(ws_config_factory=ws_config_factory, stale_timeout=0.01)
+    )
+    transport._listeners[robot.id] = robot
+    transport._reconnect_base = 0.01
+
+    task = asyncio.create_task(transport._run())
+    await asyncio.sleep(0.1)
+    transport._stop_event.set()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert websession.ws_connect.call_count > 1


### PR DESCRIPTION
## Symptom

Every Home Assistant restart writes one error and a full traceback:

```
ERROR (MainThread) [pylitterbot.transport] Unexpected error in WebSocket monitor; reconnecting in 1.0s
Traceback (most recent call last):
  File ".../pylitterbot/transport.py", line 155, in _run
    await self._connect()
  File ".../pylitterbot/transport.py", line 189, in _connect
    async with session.ws_connect(**config) as ws:
  File ".../aiohttp/client.py", line 581, in _request
    raise RuntimeError("Session is closed")
RuntimeError: Session is closed
```

Five restarts on one instance produced five of these, and none at any other time.

## Cause

`RuntimeError` is neither `ClientError` nor `OSError`, so it falls to the generic branch in `_run`:

```python
except Exception as exc:
    if isinstance(exc, (ClientError, OSError)):
        _LOGGER.warning("WebSocket error (%s); reconnecting in %.1fs", exc, delay)
    else:
        _LOGGER.exception("Unexpected error in WebSocket monitor; reconnecting in %.1fs", delay)
```

Two things are wrong there. An aiohttp session does not reopen once closed, so the scheduled reconnect cannot succeed however long the backoff grows. And the condition is neither unexpected nor worth a traceback at error level.

`Account.disconnect` is correct and is not the path involved. It unsubscribes every robot first, which sets the stop event and lets the task exit, and only then closes the session. This branch is reached when something else closes the session while the monitor still runs.

Home Assistant does exactly that. It does not unload config entries when it stops, so the `litterrobot` integration's `await account.disconnect()` in `async_unload_entry` never runs, and Home Assistant closes the shared session underneath a live monitor.

## The change

`_run` leaves the loop when the session is closed, the same as it already does for cancellation:

```python
except Exception as exc:
    if self._session_closed():
        _LOGGER.debug("Account session closed; stopping WebSocket monitor")
        break
```

A failure while the session is still open keeps its existing handling, including the backoff and the warning or exception log. Only a closed session ends the loop.

## Scope

No functional impact. The retry is futile, but the process ends before the backoff elapses, so it is one error and one traceback per restart rather than a growing loop. I want to be accurate about that rather than describe it as a spin. It is visible to every Home Assistant Litter-Robot user on every restart, and it reads like a fault when it is a normal shutdown.

## Tests

- `test_websocket_monitor_stops_when_session_is_closed` fails on `main` and passes here. It asserts `ws_connect` is attempted once rather than retried.
- `test_websocket_monitor_retries_while_session_is_open` guards the other direction, asserting an open session still reconnects after a failure.

`ruff check`, `ruff format --check` and `mypy` are clean on both files.

One note on the suite: `tests/test_mcp_tools_status.py` and the related MCP tests currently fail on an untouched checkout of `main`, 185 of them here. This branch neither adds to them nor fixes any. I compared the failure sets in both directions to confirm nothing regressed. Mentioning it so the red is not attributed to this change.
